### PR TITLE
[MCC-186539] .Net zipkin reporting calling service correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,4 +110,4 @@ The following will be added to add the httpModule to your project.  Please don't
 ZipkinTracer is (c) Medidata Solutions Worldwide and owned by its major contributors:
 * Tomoko Kwan
 * [Kenya Matsumoto](https://github.com/kenyamat)
-
+* [Brent Villanueva](https://github.com/bvillanueva-mdsol)

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Add the below additional configurations. Please verify these values and modify t
 <appSettings>
   <add key="zipkinScribeServerName" value="zipkinvm.cloudapp.net" />
   <add key="zipkinScribeServerPort" value="9410" />
-  <add key="ServiceName" value="Name of your Service i.e.Gambit" />
-  <add key="spanProcessorBatchSize" value="10" />
+  <add key="zipkinServiceName" value="Name of your Service i.e.Gambit" />
+  <add key="zipkinSpanProcessorBatchSize" value="10" />
   <add key="zipkinSampleRate" value="0.5" />
   <add key="zipkinNotToBeDisplayedDomainList" value=".xyz.com,.softwaresite.net" />
 </appSettings>
@@ -48,9 +48,9 @@ Add the below additional configurations. Please verify these values and modify t
 
 	zipkinScribeServerPort - the zipkin scribe/collector server port to connect to send the Spans
 
-	ServiceName- name of your Service that zipkin will use to label the trace
+	zipkinServiceName- name of your Service that zipkin will use to label the trace
 
-	spanProcessorBatchSize - how many Spans should be sent to the zipkin scribe/collector in one go.
+	zipkinSpanProcessorBatchSize - how many Spans should be sent to the zipkin scribe/collector in one go.
 	
 	zipkinSampleRate - 1 decimal point float value between 0 and 1.  this value will determine randomly if the current request will be traced or not.
 
@@ -71,11 +71,11 @@ The values are the same as appsettings.template.config
   <parameter name="Zipkin Scribe Server Port" description="Zipkin scribe server port" defaultValue="9410">
     <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinScribeServerPort']/@value" />
   </parameter>
-  <parameter name="Service Name" description="Service name to be traced in Zipkin" defaultValue="Gambit">
-    <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='ServiceName']/@value" />
+  <parameter name="Zipkin Service Name" description="Service name to be traced in Zipkin" defaultValue="Gambit">
+    <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinServiceName']/@value" />
   </parameter>
-  <parameter name="Span Processor Batch Size" description="Number of spans to send to zipkin collector in one go" defaultValue="10">
-    <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='spanProcessorBatchSize']/@value" />
+  <parameter name="Zipkin Span Processor Batch Size" description="Number of spans to send to zipkin collector in one go" defaultValue="10">
+    <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinSpanProcessorBatchSize']/@value" />
   </parameter>
   <parameter name="Zipkin Sample Rate" description="float between 0 and 1 to determine whether to send a zipkin trace" defaultValue="0.5">
     <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinSampleRate']/@value" />

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ Add the below additional configurations. Please verify these values and modify t
 <appSettings>
   <add key="zipkinScribeServerName" value="zipkinvm.cloudapp.net" />
   <add key="zipkinScribeServerPort" value="9410" />
-  <add key="zipkinServiceName" value="Name of your Service i.e.Gambit" />
+  <add key="zipkinServiceName" value="Name of your Service i.e. MyApplication" />
   <add key="zipkinSpanProcessorBatchSize" value="10" />
   <add key="zipkinSampleRate" value="0.5" />
-  <add key="zipkinNotToBeDisplayedDomainList" value=".xyz.com,.softwaresite.net" />
+  <add key="zipkinNotToBeDisplayedDomainList" value=".xyz.com,.myApplication.net" />
+  <add key="zipkinExcludedUriList" value="/check_uri,/status" />
 </appSettings>
 ```
 
@@ -57,9 +58,11 @@ Add the below additional configurations. Please verify these values and modify t
 	zipkinNotToBeDisplayedDomainList - comma separate domain list, it will be used when logging hostname by excluding these strings in service name attribute
                                  e.g. domain: ".xyz.com", host: "abc.xyz.com" will be logged as "abc" only    
 
+    zipkinExcludedUriList - uri list that is not needed for tracing
+
 2) parameters.xml
 
-This is used in opscode's xml when deploying service (i.e. Gambit) to customize the values to be used in appsettings.
+This is used in opscode's xml when deploying service (i.e. MyApplication) to customize the values to be used in appsettings.
 
 The values are the same as appsettings.template.config
 
@@ -71,7 +74,7 @@ The values are the same as appsettings.template.config
   <parameter name="Zipkin Scribe Server Port" description="Zipkin scribe server port" defaultValue="9410">
     <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinScribeServerPort']/@value" />
   </parameter>
-  <parameter name="Zipkin Service Name" description="Service name to be traced in Zipkin" defaultValue="Gambit">
+  <parameter name="Zipkin Service Name" description="Service name to be traced in Zipkin" defaultValue="MyApplication">
     <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinServiceName']/@value" />
   </parameter>
   <parameter name="Zipkin Span Processor Batch Size" description="Number of spans to send to zipkin collector in one go" defaultValue="10">
@@ -80,8 +83,11 @@ The values are the same as appsettings.template.config
   <parameter name="Zipkin Sample Rate" description="float between 0 and 1 to determine whether to send a zipkin trace" defaultValue="0.5">
     <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinSampleRate']/@value" />
   </parameter>
-  <parameter name="Zipkin Not To Be Displayed Domain List" description="comma separate domain list, it will be used when logging hostname by excluding these strings in service name attribute" defaultValue="0.5">
+  <parameter name="Zipkin Not To Be Displayed Domain List" description="comma separate domain list, it will be used when logging hostname by excluding these strings in service name attribute" defaultValue=".myApplication.net">
     <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinNotToBeDisplayedDomainList']/@value" />
+  </parameter>
+  <parameter name="Zipkin Excluded Uri List" description="uri list that is not needed for tracing" defaultValue="/check_uri,/status">
+    <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinExcludedUriList']/@value" />
   </parameter>
 </parameters>
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add the below additional configurations. Please verify these values and modify t
   <add key="ServiceName" value="Name of your Service i.e.Gambit" />
   <add key="spanProcessorBatchSize" value="10" />
   <add key="zipkinSampleRate" value="0.5" />
-  <add key="notToBeDisplayedDomainList" value=".xyz.com,.softwaresite.net" />
+  <add key="zipkinNotToBeDisplayedDomainList" value=".xyz.com,.softwaresite.net" />
 </appSettings>
 ```
 
@@ -54,7 +54,7 @@ Add the below additional configurations. Please verify these values and modify t
 	
 	zipkinSampleRate - 1 decimal point float value between 0 and 1.  this value will determine randomly if the current request will be traced or not.
 
-	notToBeDisplayedDomainList - comma separate domain list, it will be used when logging hostname by excluding these strings in service name attribute
+	zipkinNotToBeDisplayedDomainList - comma separate domain list, it will be used when logging hostname by excluding these strings in service name attribute
                                  e.g. domain: ".xyz.com", host: "abc.xyz.com" will be logged as "abc" only    
 
 2) parameters.xml
@@ -80,8 +80,8 @@ The values are the same as appsettings.template.config
   <parameter name="Zipkin Sample Rate" description="float between 0 and 1 to determine whether to send a zipkin trace" defaultValue="0.5">
     <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinSampleRate']/@value" />
   </parameter>
-  <parameter name="Not To Be Displayed Domain List" description="comma separate domain list, it will be used in excluding these strings when logging hostname as service name" defaultValue="0.5">
-    <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='notToBeDisplayedDomainList']/@value" />
+  <parameter name="Zipkin Not To Be Displayed Domain List" description="comma separate domain list, it will be used when logging hostname by excluding these strings in service name attribute" defaultValue="0.5">
+    <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinNotToBeDisplayedDomainList']/@value" />
   </parameter>
 </parameters>
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Add the below additional configurations. Please verify these values and modify t
   <add key="ServiceName" value="Name of your Service i.e.Gambit" />
   <add key="spanProcessorBatchSize" value="10" />
   <add key="zipkinSampleRate" value="0.5" />
+  <add key="notToBeDisplayedDomainList" value=".xyz.com,.softwaresite.net" />
 </appSettings>
 ```
 
@@ -53,7 +54,9 @@ Add the below additional configurations. Please verify these values and modify t
 	
 	zipkinSampleRate - 1 decimal point float value between 0 and 1.  this value will determine randomly if the current request will be traced or not.
 
-	
+	notToBeDisplayedDomainList - comma separate domain list, it will be used when logging hostname by excluding these strings in service name attribute
+                                 e.g. domain: ".xyz.com", host: "abc.xyz.com" will be logged as "abc" only    
+
 2) parameters.xml
 
 This is used in opscode's xml when deploying service (i.e. Gambit) to customize the values to be used in appsettings.
@@ -76,6 +79,9 @@ The values are the same as appsettings.template.config
   </parameter>
   <parameter name="Zipkin Sample Rate" description="float between 0 and 1 to determine whether to send a zipkin trace" defaultValue="0.5">
     <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinSampleRate']/@value" />
+  </parameter>
+  <parameter name="Not To Be Displayed Domain List" description="comma separate domain list, it will be used in excluding these strings when logging hostname as service name" defaultValue="0.5">
+    <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='notToBeDisplayedDomainList']/@value" />
   </parameter>
 </parameters>
 ```

--- a/content/appsettings.config.transform
+++ b/content/appsettings.config.transform
@@ -4,4 +4,5 @@
   <add key="ServiceName" value="***Service Name Here***" />
   <add key="spanProcessorBatchSize" value="10" />
   <add key="zipkinSampleRate" value="0.5" />
+  <add key="notToBeDisplayedDomainList" value=".xyz.com,.softwaresite.net" />
 </appSettings>

--- a/content/appsettings.config.transform
+++ b/content/appsettings.config.transform
@@ -1,8 +1,8 @@
 ﻿<appSettings>
   <add key="zipkinScribeServerName" value="zipkinvm.cloudapp.net" />
   <add key="zipkinScribeServerPort" value="9410" />
-  <add key="ServiceName" value="***Service Name Here***" />
-  <add key="spanProcessorBatchSize" value="10" />
+  <add key="zipkinServiceName" value="***Service Name Here***" />
+  <add key="zipkinSpanProcessorBatchSize" value="10" />
   <add key="zipkinSampleRate" value="0.5" />
   <add key="zipkinNotToBeDisplayedDomainList" value=".xyz.com,.softwaresite.net" />
 </appSettings>

--- a/content/appsettings.config.transform
+++ b/content/appsettings.config.transform
@@ -4,5 +4,5 @@
   <add key="ServiceName" value="***Service Name Here***" />
   <add key="spanProcessorBatchSize" value="10" />
   <add key="zipkinSampleRate" value="0.5" />
-  <add key="notToBeDisplayedDomainList" value=".xyz.com,.softwaresite.net" />
+  <add key="zipkinNotToBeDisplayedDomainList" value=".xyz.com,.softwaresite.net" />
 </appSettings>

--- a/content/appsettings.config.transform
+++ b/content/appsettings.config.transform
@@ -4,5 +4,6 @@
   <add key="zipkinServiceName" value="***Service Name Here***" />
   <add key="zipkinSpanProcessorBatchSize" value="10" />
   <add key="zipkinSampleRate" value="0.5" />
-  <add key="zipkinNotToBeDisplayedDomainList" value=".xyz.com,.softwaresite.net" />
+  <add key="zipkinNotToBeDisplayedDomainList" value="***Domains Here***" />
+  <add key="zipkinExcludedUriList" value="***Excluded Uris Here***" />
 </appSettings>

--- a/content/appsettings.template.config.transform
+++ b/content/appsettings.template.config.transform
@@ -4,4 +4,5 @@
   <add key="ServiceName" value="***Service Name Here***" />
   <add key="spanProcessorBatchSize" value="10" />
   <add key="zipkinSampleRate" value="0.5" />
+  <add key="notToBeDisplayedDomainList" value=".xyz.com,.softwaresite.net" />
 </appSettings>

--- a/content/appsettings.template.config.transform
+++ b/content/appsettings.template.config.transform
@@ -1,8 +1,8 @@
 ﻿<appSettings>
   <add key="zipkinScribeServerName" value="zipkinvm.cloudapp.net" />
   <add key="zipkinScribeServerPort" value="9410" />
-  <add key="ServiceName" value="***Service Name Here***" />
-  <add key="spanProcessorBatchSize" value="10" />
+  <add key="zipkinServiceName" value="***Service Name Here***" />
+  <add key="zipkinSpanProcessorBatchSize" value="10" />
   <add key="zipkinSampleRate" value="0.5" />
   <add key="zipkinNotToBeDisplayedDomainList" value=".xyz.com,.softwaresite.net" />
 </appSettings>

--- a/content/appsettings.template.config.transform
+++ b/content/appsettings.template.config.transform
@@ -4,5 +4,5 @@
   <add key="ServiceName" value="***Service Name Here***" />
   <add key="spanProcessorBatchSize" value="10" />
   <add key="zipkinSampleRate" value="0.5" />
-  <add key="notToBeDisplayedDomainList" value=".xyz.com,.softwaresite.net" />
+  <add key="zipkinNotToBeDisplayedDomainList" value=".xyz.com,.softwaresite.net" />
 </appSettings>

--- a/content/appsettings.template.config.transform
+++ b/content/appsettings.template.config.transform
@@ -4,5 +4,6 @@
   <add key="zipkinServiceName" value="***Service Name Here***" />
   <add key="zipkinSpanProcessorBatchSize" value="10" />
   <add key="zipkinSampleRate" value="0.5" />
-  <add key="zipkinNotToBeDisplayedDomainList" value=".xyz.com,.softwaresite.net" />
+  <add key="zipkinNotToBeDisplayedDomainList" value="***Domains Here***" />
+  <add key="zipkinExcludedUriList" value="***Excluded Uris Here***" />
 </appSettings>

--- a/content/parameters.xml.transform
+++ b/content/parameters.xml.transform
@@ -14,4 +14,7 @@
   <parameter name="Zipkin Sample Rate" description="float between 0 and 1 to determine whether to send a zipkin trace" defaultValue="0.5">
     <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinSampleRate']/@value" />
   </parameter>
+  <parameter name="Not To Be Displayed Domain List" description="comma separate domain list, it will be used when logging hostname by excluding these strings in service name attribute" defaultValue="0.5">
+    <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='notToBeDisplayedDomainList']/@value" />
+  </parameter>
 </parameters>

--- a/content/parameters.xml.transform
+++ b/content/parameters.xml.transform
@@ -5,11 +5,11 @@
   <parameter name="Zipkin Scribe Server Port" description="Zipkin scribe server port" defaultValue="9410">
     <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinScribeServerPort']/@value" />
   </parameter>
-  <parameter name="Service Name" description="Service name to be traced in Zipkin" defaultValue="***Service Name Here***">
-    <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='ServiceName']/@value" />
+  <parameter name="Zipkin Service Name" description="Service name to be traced in Zipkin" defaultValue="***Service Name Here***">
+    <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinServiceName']/@value" />
   </parameter>
-  <parameter name="Span Processor Batch Size" description="Number of spans to send to zipkin collector in one go" defaultValue="10">
-    <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='spanProcessorBatchSize']/@value" />
+  <parameter name="Zipkin Span Processor Batch Size" description="Number of spans to send to zipkin collector in one go" defaultValue="10">
+    <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinSpanProcessorBatchSize']/@value" />
   </parameter>
   <parameter name="Zipkin Sample Rate" description="float between 0 and 1 to determine whether to send a zipkin trace" defaultValue="0.5">
     <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinSampleRate']/@value" />

--- a/content/parameters.xml.transform
+++ b/content/parameters.xml.transform
@@ -14,7 +14,10 @@
   <parameter name="Zipkin Sample Rate" description="float between 0 and 1 to determine whether to send a zipkin trace" defaultValue="0.5">
     <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinSampleRate']/@value" />
   </parameter>
-  <parameter name="Zipkin Not To Be Displayed Domain List" description="comma separate domain list, it will be used when logging hostname by excluding these strings in service name attribute" defaultValue="0.5">
+  <parameter name="Zipkin Not To Be Displayed Domain List" description="comma separate domain list, it will be used when logging hostname by excluding these strings in service name attribute" defaultValue="***Domains Here***">
     <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinNotToBeDisplayedDomainList']/@value" />
+  </parameter>
+  <parameter name="Zipkin Excluded Uri List" description="uri list that is not needed for tracing" defaultValue="***Excluded Uris Here***">
+    <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinExcludedUriList']/@value" />
   </parameter>
 </parameters>

--- a/content/parameters.xml.transform
+++ b/content/parameters.xml.transform
@@ -14,7 +14,7 @@
   <parameter name="Zipkin Sample Rate" description="float between 0 and 1 to determine whether to send a zipkin trace" defaultValue="0.5">
     <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinSampleRate']/@value" />
   </parameter>
-  <parameter name="Not To Be Displayed Domain List" description="comma separate domain list, it will be used when logging hostname by excluding these strings in service name attribute" defaultValue="0.5">
-    <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='notToBeDisplayedDomainList']/@value" />
+  <parameter name="Zipkin Not To Be Displayed Domain List" description="comma separate domain list, it will be used when logging hostname by excluding these strings in service name attribute" defaultValue="0.5">
+    <parameterEntry kind="XmlFile" scope="\\appsettings.config$" match="//appSettings/add[@key='zipkinNotToBeDisplayedDomainList']/@value" />
   </parameter>
 </parameters>

--- a/src/Medidata.ZipkinTracer.Core.Collector/IClientProvider.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/IClientProvider.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Medidata.ZipkinTracer.Core.Collector
 {

--- a/src/Medidata.ZipkinTracer.Core.Collector/SpanCollector.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/SpanCollector.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Thrift;
+﻿using System.Collections.Concurrent;
 
 namespace Medidata.ZipkinTracer.Core.Collector
 {

--- a/src/Medidata.ZipkinTracer.Core/ITracerClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ITracerClient.cs
@@ -5,9 +5,8 @@ namespace Medidata.ZipkinTracer.Core
     public interface ITracerClient
     {
         void StartServerTrace();
-        void StartClientTrace(string clientServiceName);
+        void StartClientTrace(Uri clientService);
         void EndServerTrace(int duration);
-        void EndClientTrace(int duration, string clientServiceName);
-        void ShutDown();
+        void EndClientTrace(int duration, Uri clientService);
     }
 }

--- a/src/Medidata.ZipkinTracer.Core/ITracerClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ITracerClient.cs
@@ -1,16 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Medidata.ZipkinTracer.Core
 {
     public interface ITracerClient
     {
         void StartServerTrace();
-        void StartClientTrace();
+        void StartClientTrace(string clientServiceName);
         void EndServerTrace(int duration);
-        void EndClientTrace(int duration);
+        void EndClientTrace(int duration, string clientServiceName);
+        void ShutDown();
     }
 }

--- a/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
@@ -17,8 +17,8 @@ namespace Medidata.ZipkinTracer.Core
 
         /// <summary>
         /// comma separate domain list from config formatted to string list
-        /// will be used to exclude this strings when logging hostname as service name
-        /// e.g. domain: ".xyz.com", host: "abc.xyz.com" will be logged as abc
+        /// will be used in excluding these strings when logging hostname as service name
+        /// e.g. domain: ".xyz.com", host: "abc.xyz.com" will be logged as "abc" only
         /// </summary>
         /// <returns></returns>
         List<string> GetInternalDomainList();

--- a/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Medidata.ZipkinTracer.Core
 {
@@ -14,13 +10,6 @@ namespace Medidata.ZipkinTracer.Core
         string SpanProcessorBatchSize { get; }
         string DontSampleListCsv { get; }
         string ZipkinSampleRate { get; }
-
-        /// <summary>
-        /// comma separate domain list from config formatted to string list
-        /// will be used in excluding these strings when logging hostname as service name
-        /// e.g. domain: ".xyz.com", host: "abc.xyz.com" will be logged as "abc" only
-        /// </summary>
-        /// <returns></returns>
-        List<string> GetInternalDomainList();
+        List<string> GetNotToBeDisplayedDomainList();
     }
 }

--- a/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
@@ -14,5 +14,13 @@ namespace Medidata.ZipkinTracer.Core
         string SpanProcessorBatchSize { get; }
         string DontSampleListCsv { get; }
         string ZipkinSampleRate { get; }
+
+        /// <summary>
+        /// comma separate domain list from config formatted to string list
+        /// will be used to exclude this strings when logging hostname as service name
+        /// e.g. domain: ".xyz.com", host: "abc.xyz.com" will be logged as abc
+        /// </summary>
+        /// <returns></returns>
+        List<string> GetInternalDomainList();
     }
 }

--- a/src/Medidata.ZipkinTracer.Core/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.Core/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Medidata Solutions Inc")]
 [assembly: AssemblyProduct("Medidata.ZipkinTracer.Core")]
-[assembly: AssemblyCopyright("Copyright © Medidata Solutions Inc 2014")]
+[assembly: AssemblyCopyright("Copyright © Medidata Solutions Inc 2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.0")]
-[assembly: AssemblyFileVersion("0.2.0")]
-[assembly: AssemblyInformationalVersion("0.2.0")]
+[assembly: AssemblyVersion("0.3.0")]
+[assembly: AssemblyFileVersion("0.3.0")]
+[assembly: AssemblyInformationalVersion("0.3.0")]
 [assembly: InternalsVisibleTo("Medidata.ZipkinTracer.Core.Test")]

--- a/src/Medidata.ZipkinTracer.Core/SpanTracer.cs
+++ b/src/Medidata.ZipkinTracer.Core/SpanTracer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace Medidata.ZipkinTracer.Core
@@ -67,31 +66,27 @@ namespace Medidata.ZipkinTracer.Core
             spanCollector.Collect(span);
         }
 
-        public virtual Span SendClientSpan(string requestName, string traceId, string parentSpanId, string spanId)
+        public virtual Span SendClientSpan(string requestName, string traceId, string parentSpanId, string spanId, string clientServiceName)
         {
             var newSpan = CreateNewSpan(requestName, traceId, parentSpanId, spanId);
 
             var annotation = new Annotation()
             {
-                Host = zipkinEndpoint.GetEndpoint(serviceName),
+                Host = zipkinEndpoint.GetEndpoint(clientServiceName),
                 Timestamp = GetTimeStamp(),
                 Value = zipkinCoreConstants.CLIENT_SEND
             };
 
             newSpan.Annotations.Add(annotation);
 
-            AddBinaryAnnotation("trace_id", traceId, newSpan);
-            AddBinaryAnnotation("span_id", spanId, newSpan);
-            AddBinaryAnnotation("parent_id", parentSpanId, newSpan);
-
             return newSpan;
         }
 
-        public virtual void ReceiveClientSpan(Span span, int duration)
+        public virtual void ReceiveClientSpan(Span span, int duration, string clientServiceName)
         {
             var annotation = new Annotation()
             {
-                Host = zipkinEndpoint.GetEndpoint(serviceName),
+                Host = zipkinEndpoint.GetEndpoint(clientServiceName),
                 Duration = duration,  //duration is currently not supported by zipkin UI
                 Timestamp = GetTimeStamp(),
                 Value = zipkinCoreConstants.CLIENT_RECV

--- a/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
@@ -7,6 +7,7 @@ namespace Medidata.ZipkinTracer.Core
 {
     public class ZipkinClient : ITracerClient
     {
+        const string medidataDomain = ".imedidata.net";
         internal bool isTraceOn;
         internal SpanCollector spanCollector;
         internal SpanTracer spanTracer;
@@ -49,15 +50,12 @@ namespace Medidata.ZipkinTracer.Core
             }
         }
 
-        public void StartClientTrace(string clientServiceName)
+        public void StartClientTrace(Uri clientService)
         {
             if (isTraceOn)
             {
-                if (string.IsNullOrWhiteSpace(clientServiceName))
-                {
-                    logger.Error("clientServiceName is null or whitespace");
-                    return;
-                }
+                var clientServiceName = GetClientServiceName(clientService);
+                if (string.IsNullOrWhiteSpace(clientServiceName)) { return; }
 
                 try
                 {
@@ -75,15 +73,12 @@ namespace Medidata.ZipkinTracer.Core
             }
         }
 
-        public void EndClientTrace(int duration, string clientServiceName)
+        public void EndClientTrace(int duration, Uri clientService)
         {
             if (isTraceOn)
             {
-                if (string.IsNullOrWhiteSpace(clientServiceName))
-                {
-                    logger.Error("clientServiceName is null or whitespace");
-                    return;
-                }
+                var clientServiceName = GetClientServiceName(clientService);
+                if (string.IsNullOrWhiteSpace(clientServiceName)) { return; }
 
                 try
                 {
@@ -97,6 +92,17 @@ namespace Medidata.ZipkinTracer.Core
                     logger.Error("Error Ending Client Trace", ex);
                 }
             }
+        }
+
+        private string GetClientServiceName(Uri uri)
+        {
+            if (uri == null)
+            {
+                logger.Error("clientService uri is null");
+                return null;
+            }
+
+            return uri.Host.Replace(medidataDomain, "");
         }
 
         public void StartServerTrace()

--- a/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
@@ -17,13 +17,13 @@ namespace Medidata.ZipkinTracer.Core
         private string requestName;
         private ITraceProvider traceProvider;
         private ILog logger;
-        private List<string> internalDomainList;
+        private List<string> zipkinNotToBeDisplayedDomainList;
 
         public ZipkinClient(ITraceProvider tracerProvider, string requestName, ILog logger) : this(tracerProvider, requestName, logger, new ZipkinConfig(), new SpanCollectorBuilder()) { }
 
         public ZipkinClient(ITraceProvider traceProvider, string requestName, ILog logger, IZipkinConfig zipkinConfig, ISpanCollectorBuilder spanCollectorBuilder)
         {
-            internalDomainList = zipkinConfig.GetNotToBeDisplayedDomainList();
+            zipkinNotToBeDisplayedDomainList = zipkinConfig.GetNotToBeDisplayedDomainList();
 
             this.logger = logger;
             isTraceOn = true;
@@ -106,7 +106,7 @@ namespace Medidata.ZipkinTracer.Core
             }
 
             var host = uri.Host;
-            foreach (var domain in internalDomainList)
+            foreach (var domain in zipkinNotToBeDisplayedDomainList)
             {
                 host = host.Replace(domain, "");
             }

--- a/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
@@ -23,7 +23,7 @@ namespace Medidata.ZipkinTracer.Core
 
         public ZipkinClient(ITraceProvider traceProvider, string requestName, ILog logger, IZipkinConfig zipkinConfig, ISpanCollectorBuilder spanCollectorBuilder)
         {
-            internalDomainList = zipkinConfig.GetInternalDomainList();
+            internalDomainList = zipkinConfig.GetNotToBeDisplayedDomainList();
 
             this.logger = logger;
             isTraceOn = true;

--- a/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
@@ -2,12 +2,12 @@
 using Medidata.ZipkinTracer.Core.Collector;
 using log4net;
 using System;
+using System.Collections.Generic;
 
 namespace Medidata.ZipkinTracer.Core
 {
     public class ZipkinClient : ITracerClient
     {
-        const string medidataDomain = ".imedidata.net";
         internal bool isTraceOn;
         internal SpanCollector spanCollector;
         internal SpanTracer spanTracer;
@@ -17,11 +17,14 @@ namespace Medidata.ZipkinTracer.Core
         private string requestName;
         private ITraceProvider traceProvider;
         private ILog logger;
+        private List<string> internalDomainList;
 
         public ZipkinClient(ITraceProvider tracerProvider, string requestName, ILog logger) : this(tracerProvider, requestName, logger, new ZipkinConfig(), new SpanCollectorBuilder()) { }
 
         public ZipkinClient(ITraceProvider traceProvider, string requestName, ILog logger, IZipkinConfig zipkinConfig, ISpanCollectorBuilder spanCollectorBuilder)
         {
+            internalDomainList = zipkinConfig.GetInternalDomainList();
+
             this.logger = logger;
             isTraceOn = true;
 
@@ -102,7 +105,12 @@ namespace Medidata.ZipkinTracer.Core
                 return null;
             }
 
-            return uri.Host.Replace(medidataDomain, "");
+            var host = uri.Host;
+            foreach (var domain in internalDomainList)
+            {
+                host = host.Replace(domain, "");
+            }
+            return host;
         }
 
         public void StartServerTrace()

--- a/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
@@ -29,7 +29,7 @@ namespace Medidata.ZipkinTracer.Core
 
         public string DontSampleListCsv
         {
-            get { return ConfigurationManager.AppSettings["zipkinUriBlacklist"]; } // TODO: refactor this later if it is being used
+            get { return ConfigurationManager.AppSettings["zipkinExcludedUriList"]; }
         }
 
         public string ZipkinSampleRate

--- a/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
@@ -39,15 +39,15 @@ namespace Medidata.ZipkinTracer.Core
 
         public List<string> GetNotToBeDisplayedDomainList()
         {
-            var internalDomainList = new List<string>();
+            var zipkinNotToBeDisplayedDomainList = new List<string>();
 
-            var rawInternalDomainList = ConfigurationManager.AppSettings["notToBeDisplayedDomainList"];
+            var rawInternalDomainList = ConfigurationManager.AppSettings["zipkinNotToBeDisplayedDomainList"];
             if (!string.IsNullOrWhiteSpace(rawInternalDomainList))
             {
-                internalDomainList.AddRange(rawInternalDomainList.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries).Select(w => w.Trim()).ToList());
+                zipkinNotToBeDisplayedDomainList.AddRange(rawInternalDomainList.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries).Select(w => w.Trim()).ToList());
             }
 
-            return internalDomainList;
+            return zipkinNotToBeDisplayedDomainList;
         }
     }
 }

--- a/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Configuration;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Medidata.ZipkinTracer.Core
@@ -38,11 +37,11 @@ namespace Medidata.ZipkinTracer.Core
             get {  return ConfigurationManager.AppSettings["zipkinSampleRate"];}
         }
 
-        public List<string> GetInternalDomainList()
+        public List<string> GetNotToBeDisplayedDomainList()
         {
             var internalDomainList = new List<string>();
 
-            var rawInternalDomainList = ConfigurationManager.AppSettings["internalDomainList"];
+            var rawInternalDomainList = ConfigurationManager.AppSettings["notToBeDisplayedDomainList"];
             if (!string.IsNullOrWhiteSpace(rawInternalDomainList))
             {
                 internalDomainList.AddRange(rawInternalDomainList.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries).Select(w => w.Trim()).ToList());

--- a/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
+﻿using System.Configuration;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
 
 namespace Medidata.ZipkinTracer.Core
 {

--- a/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
@@ -9,7 +9,7 @@ namespace Medidata.ZipkinTracer.Core
     {
         public string ServiceName
         {
-            get {  return ConfigurationManager.AppSettings["ServiceName"];}
+            get { return ConfigurationManager.AppSettings["zipkinServiceName"]; }
         }
 
         public string ZipkinServerName
@@ -24,12 +24,12 @@ namespace Medidata.ZipkinTracer.Core
 
         public string SpanProcessorBatchSize
         {
-            get {  return ConfigurationManager.AppSettings["spanProcessorBatchSize"];}
+            get { return ConfigurationManager.AppSettings["zipkinSpanProcessorBatchSize"]; }
         }
 
         public string DontSampleListCsv
         {
-            get {  return ConfigurationManager.AppSettings["uriBlacklist"];} // TODO: refactor this later if it is being used
+            get { return ConfigurationManager.AppSettings["zipkinUriBlacklist"]; } // TODO: refactor this later if it is being used
         }
 
         public string ZipkinSampleRate

--- a/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
@@ -1,9 +1,11 @@
-﻿using System.Configuration;
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Medidata.ZipkinTracer.Core
 {
-    [ExcludeFromCodeCoverage]  //excluded from code coverage since this class are getters using static .net class ConfigurationManager
     public class ZipkinConfig : IZipkinConfig
     {
         public string ServiceName
@@ -28,12 +30,25 @@ namespace Medidata.ZipkinTracer.Core
 
         public string DontSampleListCsv
         {
-            get {  return ConfigurationManager.AppSettings["mAuthWhitelist"];}
+            get {  return ConfigurationManager.AppSettings["uriBlacklist"];} // TODO: refactor this later if it is being used
         }
 
         public string ZipkinSampleRate
         {
             get {  return ConfigurationManager.AppSettings["zipkinSampleRate"];}
+        }
+
+        public List<string> GetInternalDomainList()
+        {
+            var internalDomainList = new List<string>();
+
+            var rawInternalDomainList = ConfigurationManager.AppSettings["internalDomainList"];
+            if (!string.IsNullOrWhiteSpace(rawInternalDomainList))
+            {
+                internalDomainList.AddRange(rawInternalDomainList.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries).Select(w => w.Trim()).ToList());
+            }
+
+            return internalDomainList;
         }
     }
 }

--- a/src/Medidata.ZipkinTracer.HttpModule/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.HttpModule/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Medidata Solutions Inc")]
 [assembly: AssemblyProduct("Medidata.ZipkinTracer.HttpModule")]
-[assembly: AssemblyCopyright("Copyright © Medidata Solutions Inc 2014")]
+[assembly: AssemblyCopyright("Copyright © Medidata Solutions Inc 2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.0")]
-[assembly: AssemblyFileVersion("0.2.0")]
-[assembly: AssemblyInformationalVersion("0.2.0")]
+[assembly: AssemblyVersion("0.3.0")]
+[assembly: AssemblyFileVersion("0.3.0")]
+[assembly: AssemblyInformationalVersion("0.3.0")]

--- a/src/Medidata.ZipkinTracer.HttpModule/ZipkinRequestContextModule.cs
+++ b/src/Medidata.ZipkinTracer.HttpModule/ZipkinRequestContextModule.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Diagnostics;
 using System.Web;
 using Medidata.CrossApplicationTracer;
 using Medidata.ZipkinTracer.Core;

--- a/tests/Medidata.ZipkinTracer.Core.Test/Medidata.ZipkinTracer.Core.Test.csproj
+++ b/tests/Medidata.ZipkinTracer.Core.Test/Medidata.ZipkinTracer.Core.Test.csproj
@@ -62,6 +62,7 @@
       <HintPath>..\..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
     <Reference Include="Thrift">
       <HintPath>..\..\packages\Thrift.0.9.1.3\lib\net35\Thrift.dll</HintPath>
@@ -82,6 +83,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SpanTracerTests.cs" />
+    <Compile Include="ZipkinConfigTests.cs" />
     <Compile Include="ZipkinEndpointTests.cs" />
     <Compile Include="ZipkinClientTests.cs" />
   </ItemGroup>

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
@@ -359,7 +359,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         public void StartClientSpan_MultipleDomainList()
         {
             var zipkinConfig = CreateZipkinConfigWithDefaultValues();
-            zipkinConfig.Expect(x => x.GetInternalDomainList()).Return(new List<string>() { ".abc.net", ".xyz.net" });
+            zipkinConfig.Expect(x => x.GetNotToBeDisplayedDomainList()).Return(new List<string>() { ".abc.net", ".xyz.net" });
             var tracerClient = SetupZipkinClient(zipkinConfig);
             var zipkinClient = (ZipkinClient)tracerClient;
             spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
@@ -462,7 +462,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         public void EndClientSpan_MultipleDomainList()
         {
             var zipkinConfig = CreateZipkinConfigWithDefaultValues();
-            zipkinConfig.Expect(x => x.GetInternalDomainList()).Return(new List<string>() { ".abc.net", ".xyz.net" });
+            zipkinConfig.Expect(x => x.GetNotToBeDisplayedDomainList()).Return(new List<string>() { ".abc.net", ".xyz.net" });
             var tracerClient = SetupZipkinClient(zipkinConfig);
             var zipkinClient = (ZipkinClient)tracerClient;
             spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
@@ -546,7 +546,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             zipkinConfigStub.Expect(x => x.ServiceName).Return(fixture.Create<string>());
             zipkinConfigStub.Expect(x => x.DontSampleListCsv).Return("foo,bar,baz");
             zipkinConfigStub.Expect(x => x.ZipkinSampleRate).Return("0.5");
-            zipkinConfigStub.Expect(x => x.GetInternalDomainList()).Return(new List<string>() { ".xyz.net" });
+            zipkinConfigStub.Expect(x => x.GetNotToBeDisplayedDomainList()).Return(new List<string>() { ".xyz.net" });
             return zipkinConfigStub;
         }
 
@@ -559,7 +559,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             zipkinConfigStub.Expect(x => x.ServiceName).Return(serviceName);
             zipkinConfigStub.Expect(x => x.DontSampleListCsv).Return(filterListCsv);
             zipkinConfigStub.Expect(x => x.ZipkinSampleRate).Return(zipkinSampleRate);
-            zipkinConfigStub.Expect(x => x.GetInternalDomainList()).Return(domainList);
+            zipkinConfigStub.Expect(x => x.GetNotToBeDisplayedDomainList()).Return(domainList);
             return zipkinConfigStub;
         }
     }

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinConfigTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinConfigTests.cs
@@ -6,13 +6,13 @@ namespace Medidata.ZipkinTracer.Core.Test
     [TestClass]
     public class ZipkinConfigTests
     {
-        #region Get Internal Domain List
+        #region Get Not To Be Displayed Domain List
         [TestMethod]
-        public void GetInternalDomainList()
+        public void GetNotToBeDisplayedDomainList()
         {
             // Arrange
             ZipkinConfig config = new ZipkinConfig();
-            ConfigurationManager.AppSettings["notToBeDisplayedDomainList"] = ".xyz.net,.abc.com";
+            ConfigurationManager.AppSettings["zipkinNotToBeDisplayedDomainList"] = ".xyz.net,.abc.com";
 
             // Act
             var result = config.GetNotToBeDisplayedDomainList();
@@ -25,11 +25,11 @@ namespace Medidata.ZipkinTracer.Core.Test
         }
 
         [TestMethod]
-        public void GetInternalDomainListWithEmptyConfig()
+        public void GetNotToBeDisplayedDomainListWithEmptyConfig()
         {
             // Arrange
             ZipkinConfig config = new ZipkinConfig();
-            ConfigurationManager.AppSettings["notToBeDisplayedDomainList"] = "";
+            ConfigurationManager.AppSettings["zipkinNotToBeDisplayedDomainList"] = "";
 
             // Act
             var result = config.GetNotToBeDisplayedDomainList();
@@ -40,11 +40,11 @@ namespace Medidata.ZipkinTracer.Core.Test
         }
 
         [TestMethod]
-        public void GetInternalDomainListWithOnlyCommaLocalesConfigValues()
+        public void GetNotToBeDisplayedDomainListWithOnlyCommaLocalesConfigValues()
         {
             // Arrange
             ZipkinConfig config = new ZipkinConfig();
-            ConfigurationManager.AppSettings["notToBeDisplayedDomainList"] = ",";
+            ConfigurationManager.AppSettings["zipkinNotToBeDisplayedDomainList"] = ",";
 
             // Act
             var result = config.GetNotToBeDisplayedDomainList();

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinConfigTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinConfigTests.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Configuration;
+
+namespace Medidata.ZipkinTracer.Core.Test
+{
+    [TestClass]
+    public class ZipkinConfigTests
+    {
+        #region Get Internal Domain List
+        [TestMethod]
+        public void GetInternalDomainList()
+        {
+            // Arrange
+            ZipkinConfig config = new ZipkinConfig();
+            ConfigurationManager.AppSettings["internalDomainList"] = ".xyz.net,.abc.com";
+
+            // Act
+            var result = config.GetInternalDomainList();
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(".xyz.net", result[0]);
+            Assert.AreEqual(".abc.com", result[1]);
+        }
+
+        [TestMethod]
+        public void GetInternalDomainListWithEmptyConfig()
+        {
+            // Arrange
+            ZipkinConfig config = new ZipkinConfig();
+            ConfigurationManager.AppSettings["internalDomainList"] = "";
+
+            // Act
+            var result = config.GetInternalDomainList();
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public void GetInternalDomainListWithOnlyCommaLocalesConfigValues()
+        {
+            // Arrange
+            ZipkinConfig config = new ZipkinConfig();
+            ConfigurationManager.AppSettings["internalDomainList"] = ",";
+
+            // Act
+            var result = config.GetInternalDomainList();
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Count);
+        }
+        #endregion
+    }
+}

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinConfigTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinConfigTests.cs
@@ -12,10 +12,10 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             // Arrange
             ZipkinConfig config = new ZipkinConfig();
-            ConfigurationManager.AppSettings["internalDomainList"] = ".xyz.net,.abc.com";
+            ConfigurationManager.AppSettings["notToBeDisplayedDomainList"] = ".xyz.net,.abc.com";
 
             // Act
-            var result = config.GetInternalDomainList();
+            var result = config.GetNotToBeDisplayedDomainList();
 
             // Assert
             Assert.IsNotNull(result);
@@ -29,10 +29,10 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             // Arrange
             ZipkinConfig config = new ZipkinConfig();
-            ConfigurationManager.AppSettings["internalDomainList"] = "";
+            ConfigurationManager.AppSettings["notToBeDisplayedDomainList"] = "";
 
             // Act
-            var result = config.GetInternalDomainList();
+            var result = config.GetNotToBeDisplayedDomainList();
 
             // Assert
             Assert.IsNotNull(result);
@@ -44,10 +44,10 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             // Arrange
             ZipkinConfig config = new ZipkinConfig();
-            ConfigurationManager.AppSettings["internalDomainList"] = ",";
+            ConfigurationManager.AppSettings["notToBeDisplayedDomainList"] = ",";
 
             // Act
-            var result = config.GetInternalDomainList();
+            var result = config.GetNotToBeDisplayedDomainList();
 
             // Assert
             Assert.IsNotNull(result);


### PR DESCRIPTION
@kenyamat @BPONTES @jcarres-mdsol 
This PR will correct the service name logged when doing a client trace.
Client trace will accept a URI as parameter, and gets the hostname as service name when logging it to zipkin.
Added and adjusted some unit tests too.

Please review and merge if ok.

Thanks,
Brent