### PR TITLE
[MCC-186539] added try catch and logging in background thread action

### DIFF
--- a/Medidata.ZipkinTracerModule.sln
+++ b/Medidata.ZipkinTracerModule.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Medidata.ZipkinTracer.Core", "src\Medidata.ZipkinTracer.Core\Medidata.ZipkinTracer.Core.csproj", "{EB432891-204B-4B97-BFB1-A820E424284E}"
 EndProject

--- a/src/Medidata.ZipkinTracer.Core.Collector/ClientProvider.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/ClientProvider.cs
@@ -1,9 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Thrift;
 using Thrift.Protocol;
 using Thrift.Transport;
 

--- a/src/Medidata.ZipkinTracer.Core.Collector/ClientProvider.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/ClientProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Thrift.Protocol;
 using Thrift.Transport;
 
@@ -10,9 +9,8 @@ namespace Medidata.ZipkinTracer.Core.Collector
         private readonly string host;
         private readonly int port;
         private TTransport transport;
-        internal ZipkinCollector.Client Client;
-
-        internal static ClientProvider instance = null;
+        private ZipkinCollector.Client client;
+        private static ClientProvider instance;
 
         private ClientProvider(string host, int port) 
         {
@@ -25,16 +23,6 @@ namespace Medidata.ZipkinTracer.Core.Collector
             if (instance == null)
             {
                 instance = new ClientProvider(host, port);
-                try
-                {
-                    instance.Setup();
-                }
-                catch (Exception ex)
-                {
-                    instance.Close();
-                    instance = null;
-                    throw ex;
-                }
             }
             return instance;
         }
@@ -44,7 +32,7 @@ namespace Medidata.ZipkinTracer.Core.Collector
             var socket = new TSocket(host, port);
             transport = new TFramedTransport(socket);
             var protocol = new TBinaryProtocol(transport);
-            Client = new ZipkinCollector.Client(protocol);
+            client = new ZipkinCollector.Client(protocol);
             transport.Open();
         }
 
@@ -59,7 +47,15 @@ namespace Medidata.ZipkinTracer.Core.Collector
 
         public void Log(List<LogEntry> logEntries)
         {
-            Client.Log(logEntries);
+            try
+            {
+                Setup();
+                client.Log(logEntries);
+            }
+            finally
+            {
+                Close();
+            }
         }
     }
 }

--- a/src/Medidata.ZipkinTracer.Core.Collector/ISpanCollectorBuilder.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/ISpanCollectorBuilder.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using log4net;
 
 namespace Medidata.ZipkinTracer.Core.Collector
 {
     public interface ISpanCollectorBuilder
     {
-        SpanCollector Build(string zipkinServer, int zipkinPort, int maxProcessorBatchSize);
+        SpanCollector Build(string zipkinServer, int zipkinPort, int maxProcessorBatchSize, ILog logger);
     }
 }

--- a/src/Medidata.ZipkinTracer.Core.Collector/Medidata.ZipkinTracer.Core.Collector.csproj
+++ b/src/Medidata.ZipkinTracer.Core.Collector/Medidata.ZipkinTracer.Core.Collector.csproj
@@ -32,6 +32,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=692fbea5521e1304, processorArchitecture=AMD64">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Medidata.ZipkinTracer.Core.Collector/SpanCollector.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/SpanCollector.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using log4net;
 
 namespace Medidata.ZipkinTracer.Core.Collector
 {
@@ -10,7 +11,7 @@ namespace Medidata.ZipkinTracer.Core.Collector
         internal SpanProcessor spanProcessor;
         internal IClientProvider clientProvider;
 
-        public SpanCollector(IClientProvider clientProvider, int maxProcessorBatchSize)
+        public SpanCollector(IClientProvider clientProvider, int maxProcessorBatchSize, ILog logger)
         {
             if ( spanQueue == null)
             {
@@ -18,8 +19,8 @@ namespace Medidata.ZipkinTracer.Core.Collector
             }
 
             this.clientProvider = clientProvider;
-            
-            spanProcessor = new SpanProcessor(spanQueue, clientProvider, maxProcessorBatchSize);
+
+            spanProcessor = new SpanProcessor(spanQueue, clientProvider, maxProcessorBatchSize, logger);
         }
 
         public virtual void Collect(Span span)

--- a/src/Medidata.ZipkinTracer.Core.Collector/SpanCollector.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/SpanCollector.cs
@@ -9,7 +9,19 @@ namespace Medidata.ZipkinTracer.Core.Collector
         internal static BlockingCollection<Span> spanQueue;
 
         internal SpanProcessor spanProcessor;
-        internal IClientProvider clientProvider;
+        private IClientProvider clientProvider;
+
+        private static SpanCollector instance;
+
+        public static SpanCollector GetInstance(IClientProvider clientProvider, int maxProcessorBatchSize, ILog logger)
+        {
+            if (instance == null)
+            {
+                instance = new SpanCollector(clientProvider, maxProcessorBatchSize, logger);
+                instance.Start();
+            }
+            return instance;
+        }
 
         public SpanCollector(IClientProvider clientProvider, int maxProcessorBatchSize, ILog logger)
         {

--- a/src/Medidata.ZipkinTracer.Core.Collector/SpanCollectorBuilder.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/SpanCollectorBuilder.cs
@@ -1,18 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Diagnostics.CodeAnalysis;
+using log4net;
 
 namespace Medidata.ZipkinTracer.Core.Collector
 {
     [ExcludeFromCodeCoverage]  //excluded from code coverage since this class is a 1 liner to new up SpanCollector
     public class SpanCollectorBuilder : ISpanCollectorBuilder
     {
-        public SpanCollector Build(string zipkinServer, int zipkinPort, int maxProcessorBatchSize)
+        public SpanCollector Build(string zipkinServer, int zipkinPort, int maxProcessorBatchSize, ILog logger)
         {
-            return new SpanCollector(ClientProvider.GetInstance(zipkinServer, zipkinPort), maxProcessorBatchSize);
+            return new SpanCollector(ClientProvider.GetInstance(zipkinServer, zipkinPort), maxProcessorBatchSize, logger);
         }
     }
 }

--- a/src/Medidata.ZipkinTracer.Core.Collector/SpanCollectorBuilder.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/SpanCollectorBuilder.cs
@@ -8,7 +8,7 @@ namespace Medidata.ZipkinTracer.Core.Collector
     {
         public SpanCollector Build(string zipkinServer, int zipkinPort, int maxProcessorBatchSize, ILog logger)
         {
-            return new SpanCollector(ClientProvider.GetInstance(zipkinServer, zipkinPort), maxProcessorBatchSize, logger);
+            return SpanCollector.GetInstance(ClientProvider.GetInstance(zipkinServer, zipkinPort), maxProcessorBatchSize, logger);
         }
     }
 }

--- a/src/Medidata.ZipkinTracer.Core.Collector/SpanProcessor.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/SpanProcessor.cs
@@ -3,9 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+using log4net;
 using Thrift;
 using Thrift.Protocol;
 using Thrift.Transport;
@@ -27,7 +25,7 @@ namespace Medidata.ZipkinTracer.Core.Collector
         internal int retries;
         internal int maxBatchSize;
 
-        public SpanProcessor(BlockingCollection<Span> spanQueue, IClientProvider clientProvider, int maxBatchSize)
+        public SpanProcessor(BlockingCollection<Span> spanQueue, IClientProvider clientProvider, int maxBatchSize, ILog logger)
         {
             if ( spanQueue == null) 
             {
@@ -44,7 +42,7 @@ namespace Medidata.ZipkinTracer.Core.Collector
             this.maxBatchSize = maxBatchSize;
             logEntries = new List<LogEntry>();
             protocolFactory = new TBinaryProtocol.Factory();
-            spanProcessorTaskFactory = new SpanProcessorTaskFactory();
+            spanProcessorTaskFactory = new SpanProcessorTaskFactory(logger);
         }
 
         public virtual void Stop()
@@ -90,7 +88,7 @@ namespace Medidata.ZipkinTracer.Core.Collector
                 clientProvider.Log(logEntries);
                 retries = 0;
             }
-            catch (TException tEx)
+            catch (TException)
             {
                 if ( retries < 3 )
                 {

--- a/src/Medidata.ZipkinTracer.Core.Collector/SpanProcessor.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/SpanProcessor.cs
@@ -12,8 +12,8 @@ namespace Medidata.ZipkinTracer.Core.Collector
 {
     public class SpanProcessor
     {
-        //send contents of queue if it has been empty for number of polls
-        internal const int MAX_SUBSEQUENT_EMPTY_QUEUE = 5;
+        //send contents of queue if it has pending items but less than max batch size after doing max number of polls
+        internal const int MAX_NUMBER_OF_POLLS = 5;
 
         private TBinaryProtocol.Factory protocolFactory;
         internal BlockingCollection<Span> spanQueue;
@@ -21,7 +21,7 @@ namespace Medidata.ZipkinTracer.Core.Collector
 
         internal List<LogEntry> logEntries;
         internal SpanProcessorTaskFactory spanProcessorTaskFactory;
-        internal int subsequentEmptyQueueCount;
+        internal int subsequentPollCount;
         internal int retries;
         internal int maxBatchSize;
 
@@ -63,20 +63,20 @@ namespace Medidata.ZipkinTracer.Core.Collector
             if (span != null)
             {
                 logEntries.Add(Create(span));
-                subsequentEmptyQueueCount = 0;
+                subsequentPollCount = 0;
             }
-            else
+            else if (logEntries.Any())
             {
-                subsequentEmptyQueueCount++;
+                subsequentPollCount++;
             }
 
-            if (logEntries.Count() >= maxBatchSize
-                || logEntries.Any() && spanProcessorTaskFactory.IsTaskCancelled()
-                || logEntries.Any() && subsequentEmptyQueueCount > MAX_SUBSEQUENT_EMPTY_QUEUE)
+            if ((logEntries.Count() >= maxBatchSize)
+                || (logEntries.Any() && spanProcessorTaskFactory.IsTaskCancelled())
+                || (subsequentPollCount > MAX_NUMBER_OF_POLLS))
             {
                 var entries = logEntries;
                 logEntries = new List<LogEntry>();
-                subsequentEmptyQueueCount = 0;
+                subsequentPollCount = 0;
                 Log(clientProvider, entries);
             }
         }

--- a/src/Medidata.ZipkinTracer.Core.Collector/SpanProcessorTaskFactory.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/SpanProcessorTaskFactory.cs
@@ -46,6 +46,7 @@ namespace Medidata.ZipkinTracer.Core.Collector
         {
             while (!IsTaskCancelled())
             {
+                int delayTime = 500;
                 try
                 {
                     action();
@@ -53,8 +54,9 @@ namespace Medidata.ZipkinTracer.Core.Collector
                 catch (Exception ex)
                 {
                     logger.Error("Error in SpanProcessorTask", ex);
+                    delayTime = 30000;
                 }
-                await Task.Delay(500, cancellationTokenSource.Token);
+                await Task.Delay(delayTime, cancellationTokenSource.Token);
             }
         }
 

--- a/src/Medidata.ZipkinTracer.Core.Collector/SpanProcessorTaskFactory.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/SpanProcessorTaskFactory.cs
@@ -12,21 +12,18 @@ namespace Medidata.ZipkinTracer.Core.Collector
         private CancellationTokenSource cancellationTokenSource;
         private ILog logger;
 
-        public SpanProcessorTaskFactory(ILog logger)
+        public SpanProcessorTaskFactory(ILog logger, CancellationTokenSource cancellationTokenSource = null)
         {
             this.logger = logger;
-            cancellationTokenSource = new CancellationTokenSource();
-        }
 
-        /// <summary>
-        /// For unit test
-        /// </summary>
-        /// <param name="logger"></param>
-        /// <param name="cancellationTokenSource"></param>
-        public SpanProcessorTaskFactory(ILog logger, CancellationTokenSource cancellationTokenSource)
-        {
-            this.logger = logger;
-            this.cancellationTokenSource = cancellationTokenSource;
+            if (cancellationTokenSource == null)
+            {
+                this.cancellationTokenSource = new CancellationTokenSource();
+            }
+            else
+            {
+                this.cancellationTokenSource = cancellationTokenSource;
+            }
         }
 
         [ExcludeFromCodeCoverage]  //excluded from code coverage since this class is a 1 liner that starts up a background thread

--- a/src/Medidata.ZipkinTracer.Core/ITracerClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ITracerClient.cs
@@ -6,7 +6,7 @@ namespace Medidata.ZipkinTracer.Core
     {
         void StartServerTrace();
         void StartClientTrace(Uri clientService);
-        void EndServerTrace(int duration);
-        void EndClientTrace(int duration, Uri clientService);
+        void EndServerTrace();
+        void EndClientTrace(Uri clientService);
     }
 }

--- a/src/Medidata.ZipkinTracer.Core/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.Core/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.0")]
-[assembly: AssemblyFileVersion("0.3.0")]
-[assembly: AssemblyInformationalVersion("0.3.0")]
+[assembly: AssemblyVersion("0.4.0")]
+[assembly: AssemblyFileVersion("0.4.0")]
+[assembly: AssemblyInformationalVersion("0.4.0")]
 [assembly: InternalsVisibleTo("Medidata.ZipkinTracer.Core.Test")]

--- a/src/Medidata.ZipkinTracer.Core/ServiceEndpoint.cs
+++ b/src/Medidata.ZipkinTracer.Core/ServiceEndpoint.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using System.Text;
 
 namespace Medidata.ZipkinTracer.Core
 {

--- a/src/Medidata.ZipkinTracer.Core/SpanTracer.cs
+++ b/src/Medidata.ZipkinTracer.Core/SpanTracer.cs
@@ -51,12 +51,11 @@ namespace Medidata.ZipkinTracer.Core
             return newSpan;
         }
 
-        public virtual void SendServerSpan(Span span, int duration)
+        public virtual void SendServerSpan(Span span)
         {
             var annotation = new Annotation()
             {
                 Host = zipkinEndpoint.GetEndpoint(serviceName),
-                Duration = duration,  //duration is currently not supported by zipkin UI
                 Timestamp = GetTimeStamp(),
                 Value = zipkinCoreConstants.SERVER_SEND
             };
@@ -82,12 +81,11 @@ namespace Medidata.ZipkinTracer.Core
             return newSpan;
         }
 
-        public virtual void ReceiveClientSpan(Span span, int duration, string clientServiceName)
+        public virtual void ReceiveClientSpan(Span span, string clientServiceName)
         {
             var annotation = new Annotation()
             {
                 Host = zipkinEndpoint.GetEndpoint(clientServiceName),
-                Duration = duration,  //duration is currently not supported by zipkin UI
                 Timestamp = GetTimeStamp(),
                 Value = zipkinCoreConstants.CLIENT_RECV
             };

--- a/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
@@ -42,7 +42,6 @@ namespace Medidata.ZipkinTracer.Core
                         int.Parse(zipkinConfig.ZipkinServerPort),
                         int.Parse(zipkinConfig.SpanProcessorBatchSize),
                         logger);
-                    spanCollector.Start();
 
                     spanTracer = new SpanTracer(spanCollector, zipkinConfig.ServiceName, new ServiceEndpoint());
 
@@ -80,7 +79,7 @@ namespace Medidata.ZipkinTracer.Core
             }
         }
 
-        public void EndClientTrace(int duration, Uri clientService)
+        public void EndClientTrace(Uri clientService)
         {
             if (isTraceOn)
             {
@@ -91,7 +90,6 @@ namespace Medidata.ZipkinTracer.Core
                 {
                     spanTracer.ReceiveClientSpan(
                         clientSpan,
-                        duration,
                         clientServiceName);
                 }
                 catch (Exception ex)
@@ -136,15 +134,13 @@ namespace Medidata.ZipkinTracer.Core
             }
         }
 
-        public void EndServerTrace(int duration)
+        public void EndServerTrace()
         {
             if (isTraceOn)
             {
                 try
                 {
-                    spanTracer.SendServerSpan(
-                        serverSpan,
-                        duration);
+                    spanTracer.SendServerSpan(serverSpan);
                 }
                 catch (Exception ex)
                 {
@@ -220,7 +216,8 @@ namespace Medidata.ZipkinTracer.Core
                 logger.Error("traceProvider value is null");
                 return false;
             }
-            else if (string.IsNullOrEmpty(traceProvider.TraceId) || !traceProvider.IsSampled)
+
+            if (string.IsNullOrEmpty(traceProvider.TraceId) || !traceProvider.IsSampled)
             {
                 return false;
             }

--- a/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
@@ -37,7 +37,11 @@ namespace Medidata.ZipkinTracer.Core
             {
                 try
                 {
-                    spanCollector = spanCollectorBuilder.Build(zipkinConfig.ZipkinServerName, int.Parse(zipkinConfig.ZipkinServerPort), int.Parse(zipkinConfig.SpanProcessorBatchSize));
+                    spanCollector = spanCollectorBuilder.Build(
+                        zipkinConfig.ZipkinServerName,
+                        int.Parse(zipkinConfig.ZipkinServerPort),
+                        int.Parse(zipkinConfig.SpanProcessorBatchSize),
+                        logger);
                     spanCollector.Start();
 
                     spanTracer = new SpanTracer(spanCollector, zipkinConfig.ServiceName, new ServiceEndpoint());

--- a/src/Medidata.ZipkinTracer.HttpModule/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.HttpModule/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.0")]
-[assembly: AssemblyFileVersion("0.3.0")]
-[assembly: AssemblyInformationalVersion("0.3.0")]
+[assembly: AssemblyVersion("0.4.0")]
+[assembly: AssemblyFileVersion("0.4.0")]
+[assembly: AssemblyInformationalVersion("0.4.0")]

--- a/tests/Medidata.ZipkinTracer.Core.Collector.Test/Medidata.ZipkinTracer.Core.Collector.Test.csproj
+++ b/tests/Medidata.ZipkinTracer.Core.Collector.Test/Medidata.ZipkinTracer.Core.Collector.Test.csproj
@@ -37,6 +37,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=692fbea5521e1304, processorArchitecture=AMD64">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+    </Reference>
     <Reference Include="Ploeh.AutoFixture, Version=3.20.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\AutoFixture.3.20.0\lib\net40\Ploeh.AutoFixture.dll</HintPath>

--- a/tests/Medidata.ZipkinTracer.Core.Collector.Test/SpanCollectorTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Collector.Test/SpanCollectorTests.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Ploeh.AutoFixture;
 using Rhino.Mocks;
 using System.Collections.Concurrent;
-using Thrift;
+using log4net;
 
 namespace Medidata.ZipkinTracer.Core.Collector.Test
 {
@@ -14,11 +13,13 @@ namespace Medidata.ZipkinTracer.Core.Collector.Test
         private IClientProvider clientProviderStub;
         private SpanCollector spanCollector;
         private SpanProcessor spanProcessorStub;
+        private ILog logger;
 
         [TestInitialize]
         public void Init()
         {
             fixture = new Fixture();
+            logger = MockRepository.GenerateStub<ILog>();
         }
 
         [TestMethod]
@@ -27,7 +28,7 @@ namespace Medidata.ZipkinTracer.Core.Collector.Test
             SpanCollector.spanQueue = null;
 
             clientProviderStub = MockRepository.GenerateStub<IClientProvider>();
-            spanCollector = new SpanCollector(clientProviderStub, 0);
+            spanCollector = new SpanCollector(clientProviderStub, 0, logger);
 
             Assert.IsNotNull(SpanCollector.spanQueue);
         }
@@ -39,7 +40,7 @@ namespace Medidata.ZipkinTracer.Core.Collector.Test
             SpanCollector.spanQueue = spanQueue;
 
             clientProviderStub = MockRepository.GenerateStub<IClientProvider>();
-            spanCollector = new SpanCollector(clientProviderStub, 0);
+            spanCollector = new SpanCollector(clientProviderStub, 0, logger);
 
             Assert.IsTrue(System.Object.ReferenceEquals(SpanCollector.spanQueue, spanQueue));
         }
@@ -92,10 +93,10 @@ namespace Medidata.ZipkinTracer.Core.Collector.Test
         private void SetupSpanCollector()
         {
             clientProviderStub = MockRepository.GenerateStub<IClientProvider>();
-            spanCollector = new SpanCollector(clientProviderStub, 0);
+            spanCollector = new SpanCollector(clientProviderStub, 0, logger);
 
             SpanCollector.spanQueue = fixture.Create<BlockingCollection<Span>>();
-            spanProcessorStub = MockRepository.GenerateStub<SpanProcessor>(SpanCollector.spanQueue, clientProviderStub, 0);
+            spanProcessorStub = MockRepository.GenerateStub<SpanProcessor>(SpanCollector.spanQueue, clientProviderStub, 0, logger);
             spanCollector.spanProcessor = spanProcessorStub;
         }
     }

--- a/tests/Medidata.ZipkinTracer.Core.Collector.Test/SpanCollectorTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Collector.Test/SpanCollectorTests.cs
@@ -23,6 +23,17 @@ namespace Medidata.ZipkinTracer.Core.Collector.Test
         }
 
         [TestMethod]
+        public void GetInstance()
+        {
+            SpanCollector.spanQueue = null;
+
+            clientProviderStub = MockRepository.GenerateStub<IClientProvider>();
+            spanCollector = SpanCollector.GetInstance(clientProviderStub, 0, logger);
+
+            Assert.IsNotNull(SpanCollector.spanQueue);
+        }
+
+        [TestMethod]
         public void CTOR_initializesSpanCollector()
         {
             SpanCollector.spanQueue = null;

--- a/tests/Medidata.ZipkinTracer.Core.Collector.Test/SpanProcessorTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Collector.Test/SpanProcessorTests.cs
@@ -29,7 +29,7 @@ namespace Medidata.ZipkinTracer.Core.Collector.Test
             clientProvider = MockRepository.GenerateStub<IClientProvider>();
             testMaxBatchSize = 10;
             spanProcessor = new SpanProcessor(queue, clientProvider, testMaxBatchSize, logger);
-            taskFactory = MockRepository.GenerateStub<SpanProcessorTaskFactory>(logger );
+            taskFactory = MockRepository.GenerateStub<SpanProcessorTaskFactory>(logger, null);
             spanProcessor.spanProcessorTaskFactory = taskFactory;
         }
 
@@ -37,14 +37,14 @@ namespace Medidata.ZipkinTracer.Core.Collector.Test
         [ExpectedException(typeof(ArgumentNullException))]
         public void CTOR_WithNullSpanQueue()
         {
-            var spanProcessor = new SpanProcessor(null, clientProvider, fixture.Create<int>(), logger);
+            new SpanProcessor(null, clientProvider, fixture.Create<int>(), logger);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void CTOR_WithNullClientProvider()
         {
-            var spanProcessor = new SpanProcessor(new BlockingCollection<Span>(), null, fixture.Create<int>(), logger);
+            new SpanProcessor(new BlockingCollection<Span>(), null, fixture.Create<int>(), logger);
         }
 
         [TestMethod]

--- a/tests/Medidata.ZipkinTracer.Core.Collector.Test/SpanProcessorTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Collector.Test/SpanProcessorTests.cs
@@ -90,16 +90,24 @@ namespace Medidata.ZipkinTracer.Core.Collector.Test
         }
 
         [TestMethod]
-        public void LogSubmittedSpans_IncrementSubsequentEmptyQueueCountIfSpanQueueEmpty()
+        public void LogSubmittedSpans_DoNotIncrementSubsequentPollCountIfSpanQueueIsEmpty()
         {
             spanProcessor.LogSubmittedSpans();
-            Assert.AreEqual(1, spanProcessor.subsequentEmptyQueueCount);
+            Assert.AreEqual(0, spanProcessor.subsequentPollCount);
         }
 
         [TestMethod]
-        public void LogSubmittedSpans_WhenQueueIsSubsequentlyEmptyForMaxTimes()
+        public void LogSubmittedSpans_IncrementSubsequentPollCountIfSpanQueueHasAnItemLessThanMax()
         {
-            spanProcessor.subsequentEmptyQueueCount = SpanProcessor.MAX_SUBSEQUENT_EMPTY_QUEUE + 1;
+            spanProcessor.logEntries.Add(new LogEntry());
+            spanProcessor.LogSubmittedSpans();
+            Assert.AreEqual(1, spanProcessor.subsequentPollCount);
+        }
+
+        [TestMethod]
+        public void LogSubmittedSpans_WhenQueueIsSubsequentlyLessThanTheMaxBatchCountMaxTimes()
+        {
+            spanProcessor.subsequentPollCount = SpanProcessor.MAX_NUMBER_OF_POLLS + 1;
             spanProcessor.logEntries.Add(new LogEntry());
             spanProcessor.LogSubmittedSpans();
 

--- a/tests/Medidata.ZipkinTracer.Core.Collector.Test/SpanProcesssorTaskFactoryTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Collector.Test/SpanProcesssorTaskFactoryTests.cs
@@ -18,9 +18,8 @@ namespace Medidata.ZipkinTracer.Core.Collector.Test
         public void Init()
         {
             logger = MockRepository.GenerateStub<ILog>();
-            spanProcessorTaskFactory = new SpanProcessorTaskFactory(logger);
             cancellationTokenSource = new CancellationTokenSource();
-            spanProcessorTaskFactory.cancellationTokenSource = cancellationTokenSource;
+            spanProcessorTaskFactory = new SpanProcessorTaskFactory(logger, cancellationTokenSource);
             actionCalled = false;
         }
 

--- a/tests/Medidata.ZipkinTracer.Core.Collector.Test/SpanProcesssorTaskFactoryTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Collector.Test/SpanProcesssorTaskFactoryTests.cs
@@ -69,6 +69,8 @@ namespace Medidata.ZipkinTracer.Core.Collector.Test
             spanProcessorTaskFactory.ActionWrapper(myAction);
             Assert.IsTrue(actionCalled);
             Assert.IsTrue(logErrorCalled);
+
+            cancellationTokenSource.Cancel();
         }
 
         [TestMethod]

--- a/tests/Medidata.ZipkinTracer.Core.Test/SpanTracerTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/SpanTracerTests.cs
@@ -5,6 +5,7 @@ using Medidata.ZipkinTracer.Core.Collector;
 using Rhino.Mocks;
 using System.Linq;
 using System.Text;
+using log4net;
 
 namespace Medidata.ZipkinTracer.Core.Test
 {
@@ -14,12 +15,14 @@ namespace Medidata.ZipkinTracer.Core.Test
         private IFixture fixture;
         private SpanCollector spanCollectorStub;
         private ServiceEndpoint zipkinEndpointStub;
+        private ILog logger;
 
         [TestInitialize]
         public void Init()
         {
             fixture = new Fixture();
-            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(MockRepository.GenerateStub<IClientProvider>(), 0);
+            logger = MockRepository.GenerateStub<ILog>();
+            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(MockRepository.GenerateStub<IClientProvider>(), 0, logger);
             zipkinEndpointStub = MockRepository.GenerateStub<ServiceEndpoint>();
         }
 

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
@@ -16,9 +16,9 @@ namespace Medidata.ZipkinTracer.Core.Test
         private ISpanCollectorBuilder spanCollectorBuilder;
         private SpanCollector spanCollectorStub;
         private SpanTracer spanTracerStub;
-        private ServiceEndpoint zipkinEndpoint;
         private ITraceProvider traceProvider;
         private string requestName;
+        private IClientProvider clientProvider;
         private ILog logger;
 
         [TestInitialize]
@@ -26,8 +26,8 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             fixture = new Fixture();
             spanCollectorBuilder = MockRepository.GenerateStub<ISpanCollectorBuilder>();
-            zipkinEndpoint = MockRepository.GenerateStub<ServiceEndpoint>();
             traceProvider = MockRepository.GenerateStub<ITraceProvider>();
+            clientProvider = MockRepository.GenerateStub<IClientProvider>();
             logger = MockRepository.GenerateStub<ILog>();
             requestName = fixture.Create<string>();
         }
@@ -37,8 +37,8 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "123", "123", fixture.Create<string>(), "goo,bar", "0.5");
 
-            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(MockRepository.GenerateStub<IClientProvider>(), 0);
-            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything)).Return(spanCollectorStub);
+            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
+            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
 
             var zipkinClient = new ZipkinClient(traceProvider, requestName, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
@@ -49,8 +49,8 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var zipkinConfigStub = CreateZipkinConfigWithValues(null, "123", "123", fixture.Create<string>(), "goo,bar", "0.5");
 
-            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(MockRepository.GenerateStub<IClientProvider>(), 0);
-            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything)).Return(spanCollectorStub);
+            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
+            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
 
             var zipkinClient = new ZipkinClient(traceProvider, requestName, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
@@ -62,8 +62,8 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), null, "123", fixture.Create<string>(), "goo,bar" , "0.5");
 
-            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(MockRepository.GenerateStub<IClientProvider>(), 0);
-            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything)).Return(spanCollectorStub);
+            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
+            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
 
             var zipkinClient = new ZipkinClient(traceProvider, requestName, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
@@ -75,8 +75,8 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "123", null, fixture.Create<string>(), "goo,bar" , "0.5");
 
-            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(MockRepository.GenerateStub<IClientProvider>(), 0);
-            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything)).Return(spanCollectorStub);
+            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
+            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
 
             var zipkinClient = new ZipkinClient(traceProvider, requestName, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
@@ -88,8 +88,8 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "123", "123", null, "goo,bar" , "0.5");
 
-            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(MockRepository.GenerateStub<IClientProvider>(), 0);
-            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything)).Return(spanCollectorStub);
+            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
+            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
 
             var zipkinClient = new ZipkinClient(traceProvider, requestName, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
@@ -104,8 +104,8 @@ namespace Medidata.ZipkinTracer.Core.Test
 
             var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "123", "123", fixture.Create<string>(), null , "0.5");
 
-            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(MockRepository.GenerateStub<IClientProvider>(), 0);
-            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything)).Return(spanCollectorStub);
+            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
+            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
             var zipkinClient = new ZipkinClient(traceProvider, requestName, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsTrue(zipkinClient.isTraceOn);
         }
@@ -115,8 +115,8 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "123", "123", fixture.Create<string>(), "asfdsa" , null);
 
-            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(MockRepository.GenerateStub<IClientProvider>(), 0);
-            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything)).Return(spanCollectorStub);
+            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
+            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
             var zipkinClient = new ZipkinClient(traceProvider, requestName, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
             logger.AssertWasCalled(x => x.Error(Arg<string>.Is.Anything));
@@ -127,8 +127,8 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "asdf", "123", fixture.Create<string>(), "goo,bar" , "0.5");
 
-            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(MockRepository.GenerateStub<IClientProvider>(), 0);
-            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything)).Return(spanCollectorStub);
+            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
+            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
 
             var zipkinClient = new ZipkinClient(traceProvider, requestName, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
@@ -140,8 +140,8 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "123", "sfa", fixture.Create<string>(), "goo,bar" , "0.5");
 
-            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(MockRepository.GenerateStub<IClientProvider>(), 0);
-            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything)).Return(spanCollectorStub);
+            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
+            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
 
             var zipkinClient = new ZipkinClient(traceProvider, requestName, logger,zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
@@ -153,8 +153,8 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var zipkinConfigStub = CreateZipkinConfigWithDefaultValues();
 
-            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(MockRepository.GenerateStub<IClientProvider>(), 0);
-            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything)).Return(spanCollectorStub);
+            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
+            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
             var zipkinClient = new ZipkinClient(null, requestName, logger,zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
             logger.AssertWasCalled(x => x.Error(Arg<string>.Is.Anything));
@@ -168,8 +168,8 @@ namespace Medidata.ZipkinTracer.Core.Test
             traceProvider.Expect(x => x.TraceId).Return(string.Empty);
             traceProvider.Expect(x => x.IsSampled).Return(true);
 
-            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(MockRepository.GenerateStub<IClientProvider>(), 0);
-            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything)).Return(spanCollectorStub);
+            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
+            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
             var zipkinClient = new ZipkinClient(traceProvider, requestName, logger,zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
         }
@@ -182,8 +182,8 @@ namespace Medidata.ZipkinTracer.Core.Test
             traceProvider.Expect(x => x.TraceId).Return(fixture.Create<string>());
             traceProvider.Expect(x => x.IsSampled).Return(false);
 
-            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(MockRepository.GenerateStub<IClientProvider>(), 0);
-            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything)).Return(spanCollectorStub);
+            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
+            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
             var zipkinClient = new ZipkinClient(traceProvider, requestName, logger,zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
         }
@@ -191,7 +191,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         [TestMethod]
         public void CTOR_StartCollector()
         {
-            var zipkinClient = SetupZipkinClient();
+            SetupZipkinClient();
 
             spanCollectorStub.AssertWasCalled(x => x.Start()); 
         }
@@ -204,10 +204,10 @@ namespace Medidata.ZipkinTracer.Core.Test
             traceProvider.Expect(x => x.TraceId).Return(fixture.Create<string>());
             traceProvider.Expect(x => x.IsSampled).Return(true);
 
-            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(MockRepository.GenerateStub<IClientProvider>(), 0);
+            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
 
             var expectedException = new Exception();
-            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything)).Return(spanCollectorStub);
+            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
             spanCollectorStub.Expect(x => x.Start()).Throw(expectedException); 
 
             var zipkinClient = new ZipkinClient(traceProvider, requestName, logger,zipkinConfigStub, spanCollectorBuilder);
@@ -522,8 +522,8 @@ namespace Medidata.ZipkinTracer.Core.Test
 
         private ITracerClient SetupZipkinClient(IZipkinConfig zipkinConfig = null)
         {
-            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(MockRepository.GenerateStub<IClientProvider>(), 0);
-            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything)).Return(spanCollectorStub);
+            spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
+            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
 
             traceProvider.Expect(x => x.TraceId).Return(fixture.Create<string>());
             traceProvider.Expect(x => x.IsSampled).Return(true);


### PR DESCRIPTION
@kenyamat @lschreck-mdsol @BPONTES @jcarres-mdsol 

This PR is about adding robustness in zipkin client. On a background thread, this implementation will add a try catch block and logs any exception occurred. This will prevent any consumer of zipkin client to potentially crash because of unhandled exception in background threads. 

Please review and merge if ok.
Thank you.