### PR TITLE
[MCC-186539] Refactor

### DIFF
--- a/src/Medidata.ZipkinTracer.Core/ITracerClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ITracerClient.cs
@@ -4,9 +4,9 @@ namespace Medidata.ZipkinTracer.Core
 {
     public interface ITracerClient
     {
-        void StartServerTrace();
-        void StartClientTrace(Uri clientService);
-        void EndServerTrace();
-        void EndClientTrace(Uri clientService);
+        Span StartServerTrace(Uri requestUri, string methodName);
+        Span StartClientTrace(Uri requestUri, string methodName);
+        void EndServerTrace(Span serverSpan);
+        void EndClientTrace(Span clientSpan);
     }
 }

--- a/src/Medidata.ZipkinTracer.Core/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.Core/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.0")]
-[assembly: AssemblyFileVersion("0.4.0")]
-[assembly: AssemblyInformationalVersion("0.4.0")]
+[assembly: AssemblyVersion("0.5.0")]
+[assembly: AssemblyFileVersion("0.5.0")]
+[assembly: AssemblyInformationalVersion("0.5.0")]
 [assembly: InternalsVisibleTo("Medidata.ZipkinTracer.Core.Test")]

--- a/src/Medidata.ZipkinTracer.Core/SpanTracer.cs
+++ b/src/Medidata.ZipkinTracer.Core/SpanTracer.cs
@@ -32,9 +32,9 @@ namespace Medidata.ZipkinTracer.Core
             this.zipkinEndpoint = zipkinEndpoint;
         }
 
-        public virtual Span ReceiveServerSpan(string requestName, string traceId, string parentSpanId, string spanId)
+        public virtual Span ReceiveServerSpan(string spanName, string traceId, string parentSpanId, string spanId)
         {
-            var newSpan = CreateNewSpan(requestName, traceId, parentSpanId, spanId);
+            var newSpan = CreateNewSpan(spanName, traceId, parentSpanId, spanId);
 
             var annotation = new Annotation()
             {
@@ -65,9 +65,9 @@ namespace Medidata.ZipkinTracer.Core
             spanCollector.Collect(span);
         }
 
-        public virtual Span SendClientSpan(string requestName, string traceId, string parentSpanId, string spanId, string clientServiceName)
+        public virtual Span SendClientSpan(string spanName, string traceId, string parentSpanId, string spanId, string clientServiceName)
         {
-            var newSpan = CreateNewSpan(requestName, traceId, parentSpanId, spanId);
+            var newSpan = CreateNewSpan(spanName, traceId, parentSpanId, spanId);
 
             var annotation = new Annotation()
             {
@@ -81,11 +81,11 @@ namespace Medidata.ZipkinTracer.Core
             return newSpan;
         }
 
-        public virtual void ReceiveClientSpan(Span span, string clientServiceName)
+        public virtual void ReceiveClientSpan(Span span)
         {
             var annotation = new Annotation()
             {
-                Host = zipkinEndpoint.GetEndpoint(clientServiceName),
+                Host = span.Annotations[0].Host,
                 Timestamp = GetTimeStamp(),
                 Value = zipkinCoreConstants.CLIENT_RECV
             };
@@ -95,7 +95,7 @@ namespace Medidata.ZipkinTracer.Core
             spanCollector.Collect(span);
         }
 
-        private Span CreateNewSpan(string requestName, string traceId, string parentSpanId, string spanId)
+        private Span CreateNewSpan(string spanName, string traceId, string parentSpanId, string spanId)
         {
             var newSpan = new Span();
             newSpan.Id = Int64.Parse(spanId, System.Globalization.NumberStyles.HexNumber);
@@ -106,7 +106,7 @@ namespace Medidata.ZipkinTracer.Core
                 newSpan.Parent_id = Int64.Parse(parentSpanId, System.Globalization.NumberStyles.HexNumber);
             }
 
-            newSpan.Name = requestName;
+            newSpan.Name = spanName;
             newSpan.Annotations = new List<Annotation>();
             newSpan.Binary_annotations = new List<BinaryAnnotation>();
             return newSpan;

--- a/src/Medidata.ZipkinTracer.Core/SpanTracer.cs
+++ b/src/Medidata.ZipkinTracer.Core/SpanTracer.cs
@@ -83,6 +83,11 @@ namespace Medidata.ZipkinTracer.Core
 
         public virtual void ReceiveClientSpan(Span span)
         {
+            if (span.Annotations == null || span.Annotations.Count < 1)
+            {
+                throw new ArgumentNullException("Invalid span: Annotations list is invalid.");
+            }
+
             var annotation = new Annotation()
             {
                 Host = span.Annotations[0].Host,

--- a/src/Medidata.ZipkinTracer.Core/SpanTracer.cs
+++ b/src/Medidata.ZipkinTracer.Core/SpanTracer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Medidata.ZipkinTracer.Core
@@ -53,6 +54,16 @@ namespace Medidata.ZipkinTracer.Core
 
         public virtual void SendServerSpan(Span span)
         {
+            if (span == null)
+            {
+                throw new ArgumentNullException("Null server span");
+            }
+
+            if (span.Annotations == null || !span.Annotations.Any())
+            {
+                throw new ArgumentException("Invalid server span: Annotations list is invalid.");
+            }
+
             var annotation = new Annotation()
             {
                 Host = zipkinEndpoint.GetEndpoint(serviceName),
@@ -83,14 +94,19 @@ namespace Medidata.ZipkinTracer.Core
 
         public virtual void ReceiveClientSpan(Span span)
         {
-            if (span.Annotations == null || span.Annotations.Count < 1)
+            if (span == null)
             {
-                throw new ArgumentNullException("Invalid span: Annotations list is invalid.");
+                throw new ArgumentNullException("Null client span");
+            }
+
+            if (span.Annotations == null || !span.Annotations.Any())
+            {
+                throw new ArgumentException("Invalid client span: Annotations list is invalid.");
             }
 
             var annotation = new Annotation()
             {
-                Host = span.Annotations[0].Host,
+                Host = span.Annotations.First().Host,
                 Timestamp = GetTimeStamp(),
                 Value = zipkinCoreConstants.CLIENT_RECV
             };

--- a/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
@@ -26,7 +26,7 @@ namespace Medidata.ZipkinTracer.Core
             this.logger = logger;
             isTraceOn = true;
 
-            if ( logger == null || IsConfigValuesNull(zipkinConfig) || !IsConfigValuesValid(zipkinConfig) || !IsTraceProviderValidAndSamplingOn(traceProvider))
+            if ( logger == null || !IsConfigValuesValid(zipkinConfig) || !IsTraceProviderValidAndSamplingOn(traceProvider))
             {
                 isTraceOn = false;
             }
@@ -79,7 +79,7 @@ namespace Medidata.ZipkinTracer.Core
 
         public void EndClientTrace(Span clientSpan)
         {
-            if (isTraceOn && clientSpan != null)
+            if (isTraceOn)
             {
                 try
                 {
@@ -90,27 +90,6 @@ namespace Medidata.ZipkinTracer.Core
                     logger.Error("Error Ending Client Trace", ex);
                 }
             }
-        }
-
-        private string GetClientServiceName(Uri uri)
-        {
-            if (uri == null)
-            {
-                logger.Error("clientService uri is null");
-                return null;
-            }
-
-            var host = uri.Host;
-            foreach (var domain in zipkinNotToBeDisplayedDomainList)
-            {
-                host = host.Replace(domain, "");
-            }
-            return host;
-        }
-
-        private string GetSpanName(Uri uri, string methodName)
-        {
-            return string.Format("{0} {1}", methodName, uri.AbsolutePath);
         }
 
         public Span StartServerTrace(Uri requestUri, string methodName)
@@ -135,7 +114,7 @@ namespace Medidata.ZipkinTracer.Core
 
         public void EndServerTrace(Span serverSpan)
         {
-            if (isTraceOn && serverSpan != null)
+            if (isTraceOn)
             {
                 try
                 {
@@ -156,42 +135,59 @@ namespace Medidata.ZipkinTracer.Core
             }
         }
 
-        private bool IsConfigValuesNull(IZipkinConfig zipkinConfig)
+        private string GetClientServiceName(Uri uri)
+        {
+            if (uri == null)
+            {
+                logger.Error("clientService uri is null");
+                return null;
+            }
+
+            var host = uri.Host;
+            foreach (var domain in zipkinNotToBeDisplayedDomainList)
+            {
+                host = host.Replace(domain, "");
+            }
+            return host;
+        }
+
+        private string GetSpanName(Uri uri, string methodName)
+        {
+            return string.Format("{0} {1}", methodName, uri.AbsolutePath);
+        }
+
+        private bool IsConfigValuesValid(IZipkinConfig zipkinConfig)
         {
             if (String.IsNullOrEmpty(zipkinConfig.ZipkinServerName))
             {
                 logger.Error("zipkinConfig.ZipkinServerName is null");
-                return true;
+                return false;
             }
 
             if (String.IsNullOrEmpty(zipkinConfig.ZipkinServerPort))
             {
                 logger.Error("zipkinConfig.ZipkinServerPort is null");
-                return true;
+                return false;
             }
 
             if (String.IsNullOrEmpty(zipkinConfig.ServiceName))
             {
                 logger.Error("zipkinConfig.ServiceName value is null");
-                return true;
+                return false;
             }
 
             if (String.IsNullOrEmpty(zipkinConfig.SpanProcessorBatchSize))
             {
                 logger.Error("zipkinConfig.SpanProcessorBatchSize value is null");
-                return true;
+                return false;
             }
 
             if (String.IsNullOrEmpty(zipkinConfig.ZipkinSampleRate))
             {
                 logger.Error("zipkinConfig.ZipkinSampleRate value is null");
-                return true;
+                return false;
             }
-            return false;
-        }
 
-        private bool IsConfigValuesValid(IZipkinConfig zipkinConfig)
-        {
             int port;
             int spanProcessorBatchSize;
             if (!int.TryParse(zipkinConfig.ZipkinServerPort, out port))

--- a/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
@@ -11,17 +11,15 @@ namespace Medidata.ZipkinTracer.Core
         internal bool isTraceOn;
         internal SpanCollector spanCollector;
         internal SpanTracer spanTracer;
-        internal Span clientSpan;
-        internal Span serverSpan;
 
         private string requestName;
         private ITraceProvider traceProvider;
         private ILog logger;
         private List<string> zipkinNotToBeDisplayedDomainList;
 
-        public ZipkinClient(ITraceProvider tracerProvider, string requestName, ILog logger) : this(tracerProvider, requestName, logger, new ZipkinConfig(), new SpanCollectorBuilder()) { }
+        public ZipkinClient(ITraceProvider tracerProvider, ILog logger) : this(tracerProvider, logger, new ZipkinConfig(), new SpanCollectorBuilder()) { }
 
-        public ZipkinClient(ITraceProvider traceProvider, string requestName, ILog logger, IZipkinConfig zipkinConfig, ISpanCollectorBuilder spanCollectorBuilder)
+        public ZipkinClient(ITraceProvider traceProvider, ILog logger, IZipkinConfig zipkinConfig, ISpanCollectorBuilder spanCollectorBuilder)
         {
             zipkinNotToBeDisplayedDomainList = zipkinConfig.GetNotToBeDisplayedDomainList();
 
@@ -45,7 +43,6 @@ namespace Medidata.ZipkinTracer.Core
 
                     spanTracer = new SpanTracer(spanCollector, zipkinConfig.ServiceName, new ServiceEndpoint());
 
-                    this.requestName = requestName;
                     this.traceProvider = traceProvider;
                 }
                 catch (Exception ex)
@@ -56,17 +53,17 @@ namespace Medidata.ZipkinTracer.Core
             }
         }
 
-        public void StartClientTrace(Uri clientService)
+        public Span StartClientTrace(Uri clientService, string methodName)
         {
             if (isTraceOn)
             {
                 var clientServiceName = GetClientServiceName(clientService);
-                if (string.IsNullOrWhiteSpace(clientServiceName)) { return; }
+                if (string.IsNullOrWhiteSpace(clientServiceName)) { return null; }
 
                 try
                 {
-                    clientSpan = spanTracer.SendClientSpan(
-                        requestName,
+                    return spanTracer.SendClientSpan(
+                        GetSpanName(clientService, methodName),
                         traceProvider.TraceId,
                         traceProvider.ParentSpanId,
                         traceProvider.SpanId,
@@ -77,20 +74,16 @@ namespace Medidata.ZipkinTracer.Core
                     logger.Error("Error Starting Client Trace", ex);
                 }
             }
+            return null;
         }
 
-        public void EndClientTrace(Uri clientService)
+        public void EndClientTrace(Span clientSpan)
         {
-            if (isTraceOn)
+            if (isTraceOn && clientSpan != null)
             {
-                var clientServiceName = GetClientServiceName(clientService);
-                if (string.IsNullOrWhiteSpace(clientServiceName)) { return; }
-
                 try
                 {
-                    spanTracer.ReceiveClientSpan(
-                        clientSpan,
-                        clientServiceName);
+                    spanTracer.ReceiveClientSpan(clientSpan);
                 }
                 catch (Exception ex)
                 {
@@ -115,14 +108,19 @@ namespace Medidata.ZipkinTracer.Core
             return host;
         }
 
-        public void StartServerTrace()
+        private string GetSpanName(Uri uri, string methodName)
+        {
+            return string.Format("{0} {1}", methodName, uri.AbsolutePath);
+        }
+
+        public Span StartServerTrace(Uri requestUri, string methodName)
         {
             if (isTraceOn)
             {
                 try
                 {
-                    serverSpan = spanTracer.ReceiveServerSpan(
-                        requestName,
+                    return spanTracer.ReceiveServerSpan(
+                        GetSpanName(requestUri, methodName),
                         traceProvider.TraceId,
                         traceProvider.ParentSpanId,
                         traceProvider.SpanId);
@@ -132,11 +130,12 @@ namespace Medidata.ZipkinTracer.Core
                     logger.Error("Error Starting Server Trace", ex);
                 }
             }
+            return null;
         }
 
-        public void EndServerTrace()
+        public void EndServerTrace(Span serverSpan)
         {
-            if (isTraceOn)
+            if (isTraceOn && serverSpan != null)
             {
                 try
                 {

--- a/src/Medidata.ZipkinTracer.HttpModule/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.HttpModule/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.0")]
-[assembly: AssemblyFileVersion("0.4.0")]
-[assembly: AssemblyInformationalVersion("0.4.0")]
+[assembly: AssemblyVersion("0.5.0")]
+[assembly: AssemblyFileVersion("0.5.0")]
+[assembly: AssemblyInformationalVersion("0.5.0")]

--- a/src/Medidata.ZipkinTracer.HttpModule/ZipkinRequestContextModule.cs
+++ b/src/Medidata.ZipkinTracer.HttpModule/ZipkinRequestContextModule.cs
@@ -31,13 +31,6 @@ namespace Medidata.ZipkinTracer.HttpModule
                 var span = (Span)HttpContext.Current.Items["zipkinSpan"];
                 zipkinClient.EndServerTrace(span);
             };
-
-            context.Error += (sender, args) =>
-            {
-                var zipkinClient = (ITracerClient)HttpContext.Current.Items["zipkinClient"];
-                var span = (Span)HttpContext.Current.Items["zipkinSpan"];
-                zipkinClient.EndServerTrace(span);
-            };
         }
 
         public void Dispose()

--- a/tests/Medidata.ZipkinTracer.Core.Test/SpanTracerTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/SpanTracerTests.cs
@@ -156,6 +156,42 @@ namespace Medidata.ZipkinTracer.Core.Test
                     ))
                 );
         }
+        
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ReceiveClientSpan_NullAnnotation()
+        {
+            var serviceName = fixture.Create<string>();
+            var clientServiceName = fixture.Create<string>();
+            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub);
+            var endpoint = new Endpoint() { Service_name = clientServiceName };
+            var expectedSpan = new Span()
+            {
+                Annotations = null
+            };
+
+            zipkinEndpointStub.Expect(x => x.GetEndpoint(clientServiceName)).Return(endpoint);
+
+            spanTracer.ReceiveClientSpan(expectedSpan);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ReceiveClientSpan_EmptyAnnotationsList()
+        {
+            var serviceName = fixture.Create<string>();
+            var clientServiceName = fixture.Create<string>();
+            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub);
+            var endpoint = new Endpoint() { Service_name = clientServiceName };
+            var expectedSpan = new Span()
+            {
+                Annotations = new System.Collections.Generic.List<Annotation>()
+            };
+
+            zipkinEndpointStub.Expect(x => x.GetEndpoint(clientServiceName)).Return(endpoint);
+
+            spanTracer.ReceiveClientSpan(expectedSpan);
+        }
 
         private bool ValidateReceiveClientSpan(Span y, string serviceName)
         {

--- a/tests/Medidata.ZipkinTracer.Core.Test/SpanTracerTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/SpanTracerTests.cs
@@ -140,12 +140,16 @@ namespace Medidata.ZipkinTracer.Core.Test
             var serviceName = fixture.Create<string>();
             var clientServiceName = fixture.Create<string>();
             var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub);
+            var endpoint = new Endpoint() { Service_name = clientServiceName };
+            var expectedSpan = new Span()
+            {
+                Annotations = new System.Collections.Generic.List<Annotation>()
+            };
+            expectedSpan.Annotations.Add(new Annotation() { Host = endpoint, Value = zipkinCoreConstants.CLIENT_RECV, Timestamp = 1 });
 
-            var expectedSpan = new Span() { Annotations = new System.Collections.Generic.List<Annotation>() };
+            zipkinEndpointStub.Expect(x => x.GetEndpoint(clientServiceName)).Return(endpoint);
 
-            zipkinEndpointStub.Expect(x => x.GetEndpoint(clientServiceName)).Return(new Endpoint() { Service_name = clientServiceName });
-
-            spanTracer.ReceiveClientSpan(expectedSpan, clientServiceName);
+            spanTracer.ReceiveClientSpan(expectedSpan);
 
             spanCollectorStub.AssertWasCalled(x => x.Collect(Arg<Span>.Matches(y =>
                     ValidateReceiveClientSpan(y, clientServiceName)

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
@@ -17,7 +17,6 @@ namespace Medidata.ZipkinTracer.Core.Test
         private SpanCollector spanCollectorStub;
         private SpanTracer spanTracerStub;
         private ITraceProvider traceProvider;
-        private string requestName;
         private IClientProvider clientProvider;
         private ILog logger;
 
@@ -29,7 +28,6 @@ namespace Medidata.ZipkinTracer.Core.Test
             traceProvider = MockRepository.GenerateStub<ITraceProvider>();
             clientProvider = MockRepository.GenerateStub<IClientProvider>();
             logger = MockRepository.GenerateStub<ILog>();
-            requestName = fixture.Create<string>();
         }
 
         [TestMethod]
@@ -40,7 +38,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
             spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
 
-            var zipkinClient = new ZipkinClient(traceProvider, requestName, logger, zipkinConfigStub, spanCollectorBuilder);
+            var zipkinClient = new ZipkinClient(traceProvider, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
         }
 
@@ -52,7 +50,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
             spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
 
-            var zipkinClient = new ZipkinClient(traceProvider, requestName, logger, zipkinConfigStub, spanCollectorBuilder);
+            var zipkinClient = new ZipkinClient(traceProvider, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
             logger.AssertWasCalled(x => x.Error(Arg<string>.Is.Anything));
         }
@@ -60,12 +58,12 @@ namespace Medidata.ZipkinTracer.Core.Test
         [TestMethod]
         public void CTOR_WithNullZipkinPort()
         {
-            var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), null, "123", fixture.Create<string>(), "goo,bar" , "0.5");
+            var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), null, "123", fixture.Create<string>(), "goo,bar", "0.5");
 
             spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
             spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
 
-            var zipkinClient = new ZipkinClient(traceProvider, requestName, logger, zipkinConfigStub, spanCollectorBuilder);
+            var zipkinClient = new ZipkinClient(traceProvider, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
             logger.AssertWasCalled(x => x.Error(Arg<string>.Is.Anything));
         }
@@ -73,12 +71,12 @@ namespace Medidata.ZipkinTracer.Core.Test
         [TestMethod]
         public void CTOR_WithNullSpanProcessorBatchSize()
         {
-            var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "123", null, fixture.Create<string>(), "goo,bar" , "0.5");
+            var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "123", null, fixture.Create<string>(), "goo,bar", "0.5");
 
             spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
             spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
 
-            var zipkinClient = new ZipkinClient(traceProvider, requestName, logger, zipkinConfigStub, spanCollectorBuilder);
+            var zipkinClient = new ZipkinClient(traceProvider, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
             logger.AssertWasCalled(x => x.Error(Arg<string>.Is.Anything));
         }
@@ -86,12 +84,12 @@ namespace Medidata.ZipkinTracer.Core.Test
         [TestMethod]
         public void CTOR_WithNullServiceName()
         {
-            var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "123", "123", null, "goo,bar" , "0.5");
+            var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "123", "123", null, "goo,bar", "0.5");
 
             spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
             spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
 
-            var zipkinClient = new ZipkinClient(traceProvider, requestName, logger, zipkinConfigStub, spanCollectorBuilder);
+            var zipkinClient = new ZipkinClient(traceProvider, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
             logger.AssertWasCalled(x => x.Error(Arg<string>.Is.Anything));
         }
@@ -102,22 +100,22 @@ namespace Medidata.ZipkinTracer.Core.Test
             traceProvider.Expect(x => x.TraceId).Return(fixture.Create<string>());
             traceProvider.Expect(x => x.IsSampled).Return(true);
 
-            var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "123", "123", fixture.Create<string>(), null , "0.5");
+            var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "123", "123", fixture.Create<string>(), null, "0.5");
 
             spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
             spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
-            var zipkinClient = new ZipkinClient(traceProvider, requestName, logger, zipkinConfigStub, spanCollectorBuilder);
+            var zipkinClient = new ZipkinClient(traceProvider, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsTrue(zipkinClient.isTraceOn);
         }
 
         [TestMethod]
         public void CTOR_WithNullZipkinSampleRate()
         {
-            var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "123", "123", fixture.Create<string>(), "asfdsa" , null);
+            var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "123", "123", fixture.Create<string>(), "asfdsa", null);
 
             spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
             spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
-            var zipkinClient = new ZipkinClient(traceProvider, requestName, logger, zipkinConfigStub, spanCollectorBuilder);
+            var zipkinClient = new ZipkinClient(traceProvider, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
             logger.AssertWasCalled(x => x.Error(Arg<string>.Is.Anything));
         }
@@ -125,12 +123,12 @@ namespace Medidata.ZipkinTracer.Core.Test
         [TestMethod]
         public void CTOR_WithNonIntegerZipkinPort()
         {
-            var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "asdf", "123", fixture.Create<string>(), "goo,bar" , "0.5");
+            var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "asdf", "123", fixture.Create<string>(), "goo,bar", "0.5");
 
             spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
             spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
 
-            var zipkinClient = new ZipkinClient(traceProvider, requestName, logger, zipkinConfigStub, spanCollectorBuilder);
+            var zipkinClient = new ZipkinClient(traceProvider, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
             logger.AssertWasCalled(x => x.Error(Arg<string>.Is.Anything));
         }
@@ -138,12 +136,12 @@ namespace Medidata.ZipkinTracer.Core.Test
         [TestMethod]
         public void CTOR_WithNonIntegerSpanProcessorBatchSize()
         {
-            var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "123", "sfa", fixture.Create<string>(), "goo,bar" , "0.5");
+            var zipkinConfigStub = CreateZipkinConfigWithValues(fixture.Create<string>(), "123", "sfa", fixture.Create<string>(), "goo,bar", "0.5");
 
             spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
             spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
 
-            var zipkinClient = new ZipkinClient(traceProvider, requestName, logger,zipkinConfigStub, spanCollectorBuilder);
+            var zipkinClient = new ZipkinClient(traceProvider, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
             logger.AssertWasCalled(x => x.Error(Arg<string>.Is.Anything));
         }
@@ -155,7 +153,7 @@ namespace Medidata.ZipkinTracer.Core.Test
 
             spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
             spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
-            var zipkinClient = new ZipkinClient(null, requestName, logger,zipkinConfigStub, spanCollectorBuilder);
+            var zipkinClient = new ZipkinClient(null, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
             logger.AssertWasCalled(x => x.Error(Arg<string>.Is.Anything));
         }
@@ -170,7 +168,7 @@ namespace Medidata.ZipkinTracer.Core.Test
 
             spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
             spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
-            var zipkinClient = new ZipkinClient(traceProvider, requestName, logger,zipkinConfigStub, spanCollectorBuilder);
+            var zipkinClient = new ZipkinClient(traceProvider, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
         }
 
@@ -184,7 +182,7 @@ namespace Medidata.ZipkinTracer.Core.Test
 
             spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
             spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
-            var zipkinClient = new ZipkinClient(traceProvider, requestName, logger,zipkinConfigStub, spanCollectorBuilder);
+            var zipkinClient = new ZipkinClient(traceProvider, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
         }
 
@@ -207,26 +205,26 @@ namespace Medidata.ZipkinTracer.Core.Test
             spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(clientProvider, 0, logger);
 
             var expectedException = new Exception();
-            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Throw(expectedException); 
+            spanCollectorBuilder.Expect(x => x.Build(Arg<string>.Is.Anything, Arg<int>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Throw(expectedException);
 
-            var zipkinClient = new ZipkinClient(traceProvider, requestName, logger,zipkinConfigStub, spanCollectorBuilder);
+            var zipkinClient = new ZipkinClient(traceProvider, logger, zipkinConfigStub, spanCollectorBuilder);
             Assert.IsFalse(zipkinClient.isTraceOn);
         }
 
         [TestMethod]
         public void Shutdown_StopCollector()
         {
-            var zipkinClient = (ZipkinClient) SetupZipkinClient();
+            var zipkinClient = (ZipkinClient)SetupZipkinClient();
 
             zipkinClient.ShutDown();
 
-            spanCollectorStub.AssertWasCalled(x => x.Stop()); 
+            spanCollectorStub.AssertWasCalled(x => x.Stop());
         }
 
         [TestMethod]
         public void Shutdown_CollectorNullDoesntThrow()
         {
-            var zipkinClient = (ZipkinClient) SetupZipkinClient();
+            var zipkinClient = (ZipkinClient)SetupZipkinClient();
             zipkinClient.spanCollector = null;
 
             zipkinClient.ShutDown();
@@ -239,13 +237,17 @@ namespace Medidata.ZipkinTracer.Core.Test
             var zipkinClient = (ZipkinClient)tracerClient;
             spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
             zipkinClient.spanTracer = spanTracerStub;
+            var uriHost = "https://www.x@y.com";
+            var uriAbsolutePath = "/object";
+            var methodName = "GET";
+            var spanName = string.Format("{0} {1}", methodName, uriAbsolutePath);
 
             var expectedSpan = new Span();
-            spanTracerStub.Expect(x => x.ReceiveServerSpan(Arg<string>.Is.Equal(requestName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything)).Return(expectedSpan);
+            spanTracerStub.Expect(x => x.ReceiveServerSpan(Arg<string>.Is.Equal(spanName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything)).Return(expectedSpan);
 
-            tracerClient.StartServerTrace();
+            var result = tracerClient.StartServerTrace(new Uri(uriHost + uriAbsolutePath), methodName);
 
-            Assert.AreEqual(expectedSpan, zipkinClient.serverSpan);
+            Assert.AreEqual(expectedSpan, result);
         }
 
         [TestMethod]
@@ -255,13 +257,16 @@ namespace Medidata.ZipkinTracer.Core.Test
             var zipkinClient = (ZipkinClient)tracerClient;
             spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
             zipkinClient.spanTracer = spanTracerStub;
+            var uriHost = "https://www.x@y.com";
+            var uriAbsolutePath = "/object";
+            var methodName = "GET";
+            var spanName = string.Format("{0} {1}", methodName, uriAbsolutePath);
 
-            var expectedSpan = new Span();
-            spanTracerStub.Expect(x => x.ReceiveServerSpan(Arg<string>.Is.Equal(requestName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything)).Throw(new Exception());
+            spanTracerStub.Expect(x => x.ReceiveServerSpan(Arg<string>.Is.Equal(spanName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything)).Throw(new Exception());
 
-            tracerClient.StartServerTrace();
+            var result = tracerClient.StartServerTrace(new Uri(uriHost + uriAbsolutePath), methodName);
 
-            Assert.AreEqual(null, zipkinClient.serverSpan);
+            Assert.IsNull(result);
         }
 
         [TestMethod]
@@ -270,10 +275,13 @@ namespace Medidata.ZipkinTracer.Core.Test
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
             zipkinClient.isTraceOn = false;
+            var uriHost = "https://www.x@y.com";
+            var uriAbsolutePath = "/object";
+            var methodName = "GET";
 
-            tracerClient.StartServerTrace();
+            var result = tracerClient.StartServerTrace(new Uri(uriHost + uriAbsolutePath), methodName);
 
-            Assert.AreEqual(null, zipkinClient.serverSpan);
+            Assert.IsNull(result);
         }
 
         [TestMethod]
@@ -283,11 +291,11 @@ namespace Medidata.ZipkinTracer.Core.Test
             var zipkinClient = (ZipkinClient)tracerClient;
             spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
             zipkinClient.spanTracer = spanTracerStub;
-            zipkinClient.serverSpan = new Span();
+            var serverSpan = new Span();
 
-            tracerClient.EndServerTrace();
+            tracerClient.EndServerTrace(serverSpan);
 
-            spanTracerStub.AssertWasCalled(x => x.SendServerSpan(zipkinClient.serverSpan));
+            spanTracerStub.AssertWasCalled(x => x.SendServerSpan(serverSpan));
         }
 
         [TestMethod]
@@ -297,11 +305,11 @@ namespace Medidata.ZipkinTracer.Core.Test
             var zipkinClient = (ZipkinClient)tracerClient;
             spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
             zipkinClient.spanTracer = spanTracerStub;
-            zipkinClient.clientSpan = new Span();
+            var serverSpan = new Span();
 
-            spanTracerStub.Expect(x => x.SendServerSpan(zipkinClient.serverSpan)).Throw(new Exception());
+            spanTracerStub.Expect(x => x.SendServerSpan(serverSpan)).Throw(new Exception());
 
-            tracerClient.EndServerTrace();
+            tracerClient.EndServerTrace(serverSpan);
         }
 
         [TestMethod]
@@ -310,8 +318,17 @@ namespace Medidata.ZipkinTracer.Core.Test
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
             zipkinClient.isTraceOn = false;
+            var serverSpan = new Span();
 
-            tracerClient.EndServerTrace();
+            tracerClient.EndServerTrace(serverSpan);
+        }
+
+        [TestMethod]
+        public void EndServerSpan_NullServerSpan_DoesntThrow()
+        {
+            var tracerClient = SetupZipkinClient();
+
+            tracerClient.EndServerTrace(null);
         }
 
         [TestMethod]
@@ -322,14 +339,16 @@ namespace Medidata.ZipkinTracer.Core.Test
             spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
             zipkinClient.spanTracer = spanTracerStub;
             var clientServiceName = "abc-sandbox";
-            var clientServiceUri = new Uri("https://"+clientServiceName+".xyz.net:8000/");
+            var uriAbsolutePath = "/object";
+            var methodName = "GET";
+            var spanName = string.Format("{0} {1}", methodName, uriAbsolutePath);
 
             var expectedSpan = new Span();
-            spanTracerStub.Expect(x => x.SendClientSpan(Arg<string>.Is.Equal(requestName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Equal(clientServiceName))).Return(expectedSpan);
+            spanTracerStub.Expect(x => x.SendClientSpan(Arg<string>.Is.Equal(spanName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Equal(clientServiceName))).Return(expectedSpan);
 
-            tracerClient.StartClientTrace(clientServiceUri);
+            var result = tracerClient.StartClientTrace(new Uri("https://" + clientServiceName + ".xyz.net:8000" + uriAbsolutePath), methodName);
 
-            Assert.AreEqual(expectedSpan, zipkinClient.clientSpan);
+            Assert.AreEqual(expectedSpan, result);
         }
 
         [TestMethod]
@@ -340,14 +359,16 @@ namespace Medidata.ZipkinTracer.Core.Test
             spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
             zipkinClient.spanTracer = spanTracerStub;
             var clientServiceName = "192.168.178.178";
-            var clientServiceUri = new Uri("https://" + clientServiceName + ":8000/");
+            var uriAbsolutePath = "/object";
+            var methodName = "GET";
+            var spanName = string.Format("{0} {1}", methodName, uriAbsolutePath);
 
             var expectedSpan = new Span();
-            spanTracerStub.Expect(x => x.SendClientSpan(Arg<string>.Is.Equal(requestName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Equal(clientServiceName))).Return(expectedSpan);
+            spanTracerStub.Expect(x => x.SendClientSpan(Arg<string>.Is.Equal(spanName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Equal(clientServiceName))).Return(expectedSpan);
 
-            tracerClient.StartClientTrace(clientServiceUri);
+            var result = tracerClient.StartClientTrace(new Uri("https://" + clientServiceName + ".xyz.net:8000" + uriAbsolutePath), methodName);
 
-            Assert.AreEqual(expectedSpan, zipkinClient.clientSpan);
+            Assert.AreEqual(expectedSpan, result);
         }
 
         [TestMethod]
@@ -360,14 +381,16 @@ namespace Medidata.ZipkinTracer.Core.Test
             spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
             zipkinClient.spanTracer = spanTracerStub;
             var clientServiceName = "abc-sandbox";
-            var clientServiceUri = new Uri("https://"+clientServiceName+".xyz.net:8000/");
+            var uriAbsolutePath = "/object";
+            var methodName = "GET";
+            var spanName = string.Format("{0} {1}", methodName, uriAbsolutePath);
 
             var expectedSpan = new Span();
-            spanTracerStub.Expect(x => x.SendClientSpan(Arg<string>.Is.Equal(requestName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Equal(clientServiceName))).Return(expectedSpan);
+            spanTracerStub.Expect(x => x.SendClientSpan(Arg<string>.Is.Equal(spanName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Equal(clientServiceName))).Return(expectedSpan);
 
-            tracerClient.StartClientTrace(clientServiceUri);
+            var result = tracerClient.StartClientTrace(new Uri("https://" + clientServiceName + ".xyz.net:8000" + uriAbsolutePath), methodName);
 
-            Assert.AreEqual(expectedSpan, zipkinClient.clientSpan);
+            Assert.AreEqual(expectedSpan, result);
         }
 
         [TestMethod]
@@ -378,13 +401,15 @@ namespace Medidata.ZipkinTracer.Core.Test
             spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
             zipkinClient.spanTracer = spanTracerStub;
             var clientServiceName = "abc-sandbox";
-            var clientServiceUri = new Uri("https://" + clientServiceName + ".xyz.net:8000/");
+            var uriAbsolutePath = "/object";
+            var methodName = "GET";
+            var spanName = string.Format("{0} {1}", methodName, uriAbsolutePath);
 
-            spanTracerStub.Expect(x => x.SendClientSpan(Arg<string>.Is.Equal(requestName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Equal(clientServiceName))).Throw(new Exception());
+            spanTracerStub.Expect(x => x.SendClientSpan(Arg<string>.Is.Equal(spanName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Equal(clientServiceName))).Throw(new Exception());
 
-            tracerClient.StartClientTrace(clientServiceUri);
+            var result = tracerClient.StartClientTrace(new Uri("https://" + clientServiceName + ".xyz.net:8000" + uriAbsolutePath), methodName);
 
-            Assert.AreEqual(null, zipkinClient.clientSpan);
+            Assert.IsNull(result);
         }
 
         [TestMethod]
@@ -394,13 +419,11 @@ namespace Medidata.ZipkinTracer.Core.Test
             var zipkinClient = (ZipkinClient)tracerClient;
             spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
             zipkinClient.spanTracer = spanTracerStub;
+            var methodName = "GET";
 
-            var expectedSpan = new Span();
-            spanTracerStub.Expect(x => x.SendClientSpan(Arg<string>.Is.Equal(requestName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything)).Return(expectedSpan);
+            var result = tracerClient.StartClientTrace(null, methodName);
 
-            tracerClient.StartClientTrace(null);
-
-            Assert.AreEqual(null, zipkinClient.clientSpan);
+            Assert.IsNull(result);
         }
 
         [TestMethod]
@@ -410,11 +433,12 @@ namespace Medidata.ZipkinTracer.Core.Test
             var zipkinClient = (ZipkinClient)tracerClient;
             zipkinClient.isTraceOn = false;
             var clientServiceName = "abc-sandbox";
-            var clientServiceUri = new Uri("https://" + clientServiceName + ".xyz.net:8000/");
+            var clientServiceUri = new Uri("https://" + clientServiceName + ".xyz.net:8000");
+            var methodName = "GET";
 
-            tracerClient.StartClientTrace(clientServiceUri);
+            var result = tracerClient.StartClientTrace(clientServiceUri, methodName);
 
-            Assert.AreEqual(null, zipkinClient.serverSpan);
+            Assert.IsNull(result);
         }
 
         [TestMethod]
@@ -424,50 +448,11 @@ namespace Medidata.ZipkinTracer.Core.Test
             var zipkinClient = (ZipkinClient)tracerClient;
             spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
             zipkinClient.spanTracer = spanTracerStub;
-            zipkinClient.clientSpan = new Span();
+            var clientSpan = new Span();
 
-            var clientServiceName = "abc-sandbox";
-            var clientServiceUri = new Uri("https://" + clientServiceName + ".xyz.net:8000/");
+            tracerClient.EndClientTrace(clientSpan);
 
-            tracerClient.EndClientTrace(clientServiceUri);
-
-            spanTracerStub.AssertWasCalled(x => x.ReceiveClientSpan(zipkinClient.clientSpan, clientServiceName));
-        }
-
-        [TestMethod]
-        public void EndClientSpan_UsingIpAddress()
-        {
-            var tracerClient = SetupZipkinClient();
-            var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
-            zipkinClient.spanTracer = spanTracerStub;
-            zipkinClient.clientSpan = new Span();
-
-            var clientServiceName = "192.168.178.178";
-            var clientServiceUri = new Uri("https://" + clientServiceName + ":8000/");
-
-            tracerClient.EndClientTrace(clientServiceUri);
-
-            spanTracerStub.AssertWasCalled(x => x.ReceiveClientSpan(zipkinClient.clientSpan, clientServiceName));
-        }
-
-        [TestMethod]
-        public void EndClientSpan_MultipleDomainList()
-        {
-            var zipkinConfig = CreateZipkinConfigWithDefaultValues();
-            zipkinConfig.Expect(x => x.GetNotToBeDisplayedDomainList()).Return(new List<string>() { ".abc.net", ".xyz.net" });
-            var tracerClient = SetupZipkinClient(zipkinConfig);
-            var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
-            zipkinClient.spanTracer = spanTracerStub;
-            zipkinClient.clientSpan = new Span();
-
-            var clientServiceName = "abc-sandbox";
-            var clientServiceUri = new Uri("https://" + clientServiceName + ".xyz.net:8000/");
-
-            tracerClient.EndClientTrace(clientServiceUri);
-
-            spanTracerStub.AssertWasCalled(x => x.ReceiveClientSpan(zipkinClient.clientSpan, clientServiceName));
+            spanTracerStub.AssertWasCalled(x => x.ReceiveClientSpan(clientSpan));
         }
 
         [TestMethod]
@@ -477,37 +462,43 @@ namespace Medidata.ZipkinTracer.Core.Test
             var zipkinClient = (ZipkinClient)tracerClient;
             spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
             zipkinClient.spanTracer = spanTracerStub;
-            zipkinClient.clientSpan = new Span();
+            var clientSpan = new Span();
 
-            var clientServiceName = "abc-sandbox";
-            var clientServiceUri = new Uri("https://" + clientServiceName + ".xyz.net:8000/");
+            spanTracerStub.Expect(x => x.ReceiveClientSpan(clientSpan)).Throw(new Exception());
 
-            spanTracerStub.Expect(x => x.ReceiveClientSpan(zipkinClient.clientSpan, clientServiceName)).Throw(new Exception());
-
-            tracerClient.EndClientTrace(clientServiceUri);
+            tracerClient.EndClientTrace(clientSpan);
         }
 
         [TestMethod]
-        public void EndClientSpan_InvalidClientServiceName()
+        public void EndClientSpan_NullClientTrace_DoesntThrow()
         {
             var tracerClient = SetupZipkinClient();
             spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
 
+            var called = false;
+            spanTracerStub.Stub(x => x.ReceiveClientSpan(Arg<Span>.Is.Anything))
+                .WhenCalled(x => { called = true; });
+
             tracerClient.EndClientTrace(null);
 
-            spanTracerStub.AssertWasNotCalled(x => x.ReceiveClientSpan(Arg<Span>.Is.Anything, Arg<string>.Is.Anything));
+            Assert.IsFalse(called);
         }
 
         [TestMethod]
         public void EndClientSpan_IsTraceOnIsFalse_DoesntThrow()
         {
             var tracerClient = SetupZipkinClient();
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
             var zipkinClient = (ZipkinClient)tracerClient;
             zipkinClient.isTraceOn = false;
-            var clientServiceName = "abc-sandbox";
-            var clientServiceUri = new Uri("https://" + clientServiceName + ".xyz.net:8000/");
 
-            tracerClient.EndClientTrace(clientServiceUri);
+            var called = false;
+            spanTracerStub.Stub(x => x.ReceiveClientSpan(Arg<Span>.Is.Anything))
+                .WhenCalled(x => { called = true; });
+
+            tracerClient.EndClientTrace(new Span());
+
+            Assert.IsFalse(called);
         }
 
         private ITracerClient SetupZipkinClient(IZipkinConfig zipkinConfig = null)
@@ -524,7 +515,7 @@ namespace Medidata.ZipkinTracer.Core.Test
                 zipkinConfigSetup = CreateZipkinConfigWithDefaultValues();
             }
 
-            return new ZipkinClient(traceProvider, requestName, logger, zipkinConfigSetup, spanCollectorBuilder);
+            return new ZipkinClient(traceProvider, logger, zipkinConfigSetup, spanCollectorBuilder);
         }
 
         private IZipkinConfig CreateZipkinConfigWithDefaultValues()
@@ -541,7 +532,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         }
 
         private IZipkinConfig CreateZipkinConfigWithValues(string zipkinServerName, string zipkinServerPort, string spanProcessorBatchSize, string serviceName, string filterListCsv, string zipkinSampleRate, List<string> domainList = null)
-        { 
+        {
             var zipkinConfigStub = MockRepository.GenerateStub<IZipkinConfig>();
             zipkinConfigStub.Expect(x => x.ZipkinServerName).Return(zipkinServerName);
             zipkinConfigStub.Expect(x => x.ZipkinServerPort).Return(zipkinServerPort);


### PR DESCRIPTION
@kenyamat @jcarres-mdsol @BPONTES @lschreck-mdsol 

This PR corrects the span name information resulting to some interface change on zipkin client.

- Span name has now has a format of --> "{Context Method Name} {Context Absolute path}"
- Start Trace returns a span which should be used on later when doing stop trace passing the same span instance.

Please review if change is ok and merge.

Thanks,
Brent