### PR TITLE
[MCC-196748] improvement on submitted data for UI

### DIFF
--- a/src/Medidata.ZipkinTracer.Core.Collector/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1")]
-[assembly: AssemblyFileVersion("1.0.1")]
-[assembly: AssemblyInformationalVersion("1.0.1")]
+[assembly: AssemblyVersion("1.0.2")]
+[assembly: AssemblyFileVersion("1.0.2")]
+[assembly: AssemblyInformationalVersion("1.0.2")]
 [assembly: InternalsVisibleTo("Medidata.ZipkinTracer.Core.Collector.Test")]

--- a/src/Medidata.ZipkinTracer.Core.Collector/SerializableBinaryAnnotation.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/SerializableBinaryAnnotation.cs
@@ -15,7 +15,7 @@ namespace Medidata.ZipkinTracer.Core.Collector
         public string Key { get; private set; }
 
         [JsonProperty("value")]
-        public byte[] Value { get; private set; }
+        public string  Value { get; private set; }
 
         [JsonProperty("endpoint")]
         public SerializableEndpoint SerializableEndpoint { get; private set; }

--- a/src/Medidata.ZipkinTracer.Core.Collector/SerializableSpan.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/SerializableSpan.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Globalization;
 using Newtonsoft.Json;
 
 namespace Medidata.ZipkinTracer.Core.Collector

--- a/src/Medidata.ZipkinTracer.Core.Collector/thrift/gen-sharp/BinaryAnnotation.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/thrift/gen-sharp/BinaryAnnotation.cs
@@ -22,7 +22,7 @@ using Thrift.Transport;
 public partial class BinaryAnnotation : TBase
 {
   private string _key;
-  private byte[] _value;
+  private string _value;
   private AnnotationType _annotation_type;
   private Endpoint _host;
 
@@ -39,7 +39,7 @@ public partial class BinaryAnnotation : TBase
     }
   }
 
-  public byte[] Value
+  public string Value
   {
     get
     {
@@ -118,7 +118,7 @@ public partial class BinaryAnnotation : TBase
           break;
         case 2:
           if (field.Type == TType.String) {
-            Value = iprot.ReadBinary();
+            Value = iprot.ReadString();
           } else { 
             TProtocolUtil.Skip(iprot, field.Type);
           }
@@ -164,7 +164,7 @@ public partial class BinaryAnnotation : TBase
       field.Type = TType.String;
       field.ID = 2;
       oprot.WriteFieldBegin(field);
-      oprot.WriteBinary(Value);
+      oprot.WriteString(Value);
       oprot.WriteFieldEnd();
     }
     if (__isset.annotation_type) {

--- a/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Medidata.ZipkinTracer.Core
 {

--- a/src/Medidata.ZipkinTracer.Core/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.Core/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2")]
-[assembly: AssemblyFileVersion("1.0.2")]
-[assembly: AssemblyInformationalVersion("1.0.2")]
+[assembly: AssemblyVersion("1.0.3")]
+[assembly: AssemblyFileVersion("1.0.3")]
+[assembly: AssemblyInformationalVersion("1.0.3")]
 [assembly: InternalsVisibleTo("Medidata.ZipkinTracer.Core.Test")]

--- a/src/Medidata.ZipkinTracer.Core/SpanTracer.cs
+++ b/src/Medidata.ZipkinTracer.Core/SpanTracer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Medidata.ZipkinTracer.Core
 {
@@ -33,7 +32,7 @@ namespace Medidata.ZipkinTracer.Core
             this.zipkinEndpoint = zipkinEndpoint;
         }
 
-        public virtual Span ReceiveServerSpan(string spanName, string traceId, string parentSpanId, string spanId)
+        public virtual Span ReceiveServerSpan(string spanName, string traceId, string parentSpanId, string spanId, string path)
         {
             var newSpan = CreateNewSpan(spanName, traceId, parentSpanId, spanId);
 
@@ -45,9 +44,7 @@ namespace Medidata.ZipkinTracer.Core
             };
             newSpan.Annotations.Add(annotation);
 
-            AddBinaryAnnotation("trace_id", traceId, newSpan);
-            AddBinaryAnnotation("span_id", spanId, newSpan);
-            AddBinaryAnnotation("parent_id", parentSpanId, newSpan);
+            AddBinaryAnnotation("http.uri", path, newSpan);
 
             return newSpan;
         }
@@ -76,7 +73,7 @@ namespace Medidata.ZipkinTracer.Core
             spanCollector.Collect(span);
         }
 
-        public virtual Span SendClientSpan(string spanName, string traceId, string parentSpanId, string spanId, string clientServiceName)
+        public virtual Span SendClientSpan(string spanName, string traceId, string parentSpanId, string spanId, string clientServiceName, string path)
         {
             var newSpan = CreateNewSpan(spanName, traceId, parentSpanId, spanId);
 
@@ -88,6 +85,7 @@ namespace Medidata.ZipkinTracer.Core
             };
 
             newSpan.Annotations.Add(annotation);
+            AddBinaryAnnotation("http.uri", path, newSpan);
 
             return newSpan;
         }
@@ -146,7 +144,7 @@ namespace Medidata.ZipkinTracer.Core
                 Host = zipkinEndpoint.GetEndpoint(serviceName),
                 Annotation_type = AnnotationType.STRING,
                 Key = key,
-                Value = Encoding.Default.GetBytes(value)
+                Value = value
             };
 
             span.Binary_annotations.Add(binaryAnnotation);

--- a/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
@@ -60,12 +60,14 @@ namespace Medidata.ZipkinTracer.Core
 
                 try
                 {
+                    var nextTrace = traceProvider.GetNext();
                     return spanTracer.SendClientSpan(
-                        GetSpanName(clientService, methodName),
-                        traceProvider.TraceId,
-                        traceProvider.ParentSpanId,
-                        traceProvider.SpanId,
-                        clientServiceName);
+                        methodName.ToLower(),
+                        nextTrace.TraceId,
+                        nextTrace.ParentSpanId,
+                        nextTrace.SpanId,
+                        clientServiceName,
+                        clientService.AbsolutePath);
                 }
                 catch (Exception ex)
                 {
@@ -97,10 +99,11 @@ namespace Medidata.ZipkinTracer.Core
                 try
                 {
                     return spanTracer.ReceiveServerSpan(
-                        GetSpanName(requestUri, methodName),
+                        methodName.ToLower(),
                         traceProvider.TraceId,
                         traceProvider.ParentSpanId,
-                        traceProvider.SpanId);
+                        traceProvider.SpanId,
+                        requestUri.AbsolutePath);
                 }
                 catch (Exception ex)
                 {
@@ -147,11 +150,6 @@ namespace Medidata.ZipkinTracer.Core
                 host = host.Replace(domain, "");
             }
             return host;
-        }
-
-        private string GetSpanName(Uri uri, string methodName)
-        {
-            return string.Format("{0} {1}", methodName, uri.AbsolutePath);
         }
 
         private bool IsConfigValuesValid(IZipkinConfig zipkinConfig)

--- a/src/Medidata.ZipkinTracer.HttpModule/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.HttpModule/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2")]
-[assembly: AssemblyFileVersion("1.0.2")]
-[assembly: AssemblyInformationalVersion("1.0.2")]
+[assembly: AssemblyVersion("1.0.3")]
+[assembly: AssemblyFileVersion("1.0.3")]
+[assembly: AssemblyInformationalVersion("1.0.3")]

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
@@ -18,6 +18,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         private SpanCollector spanCollectorStub;
         private SpanTracer spanTracerStub;
         private ITraceProvider traceProvider;
+        private ITraceProvider nextTraceProvider;
         private ILog logger;
 
         [TestInitialize]
@@ -26,6 +27,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             fixture = new Fixture();
             spanCollectorBuilder = MockRepository.GenerateStub<ISpanCollectorBuilder>();
             traceProvider = MockRepository.GenerateStub<ITraceProvider>();
+            nextTraceProvider = MockRepository.GenerateStub<ITraceProvider>();
             logger = MockRepository.GenerateStub<ILog>();
         }
 
@@ -213,10 +215,16 @@ namespace Medidata.ZipkinTracer.Core.Test
             var uriHost = "https://www.x@y.com";
             var uriAbsolutePath = "/object";
             var methodName = "GET";
-            var spanName = string.Format("{0} {1}", methodName, uriAbsolutePath);
+            var spanName = methodName;
 
             var expectedSpan = new Span();
-            spanTracerStub.Expect(x => x.ReceiveServerSpan(Arg<string>.Is.Equal(spanName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything)).Return(expectedSpan);
+            spanTracerStub.Expect(
+                x => x.ReceiveServerSpan(
+                    Arg<string>.Is.Equal(spanName.ToLower()),
+                    Arg<string>.Is.Equal(traceProvider.TraceId),
+                    Arg<string>.Is.Equal(traceProvider.ParentSpanId),
+                    Arg<string>.Is.Equal(traceProvider.SpanId),
+                    Arg<string>.Is.Anything)).Return(expectedSpan);
 
             var result = tracerClient.StartServerTrace(new Uri(uriHost + uriAbsolutePath), methodName);
 
@@ -233,9 +241,15 @@ namespace Medidata.ZipkinTracer.Core.Test
             var uriHost = "https://www.x@y.com";
             var uriAbsolutePath = "/object";
             var methodName = "GET";
-            var spanName = string.Format("{0} {1}", methodName, uriAbsolutePath);
+            var spanName = methodName;
 
-            spanTracerStub.Expect(x => x.ReceiveServerSpan(Arg<string>.Is.Equal(spanName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything)).Throw(new Exception());
+            spanTracerStub.Expect(
+                x => x.ReceiveServerSpan(
+                    Arg<string>.Is.Equal(spanName.ToLower()),
+                    Arg<string>.Is.Anything,
+                    Arg<string>.Is.Anything,
+                    Arg<string>.Is.Anything,
+                    Arg<string>.Is.Anything)).Throw(new Exception());
 
             var result = tracerClient.StartServerTrace(new Uri(uriHost + uriAbsolutePath), methodName);
 
@@ -314,10 +328,17 @@ namespace Medidata.ZipkinTracer.Core.Test
             var clientServiceName = "abc-sandbox";
             var uriAbsolutePath = "/object";
             var methodName = "GET";
-            var spanName = string.Format("{0} {1}", methodName, uriAbsolutePath);
+            var spanName = methodName;
 
             var expectedSpan = new Span();
-            spanTracerStub.Expect(x => x.SendClientSpan(Arg<string>.Is.Equal(spanName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Equal(clientServiceName))).Return(expectedSpan);
+            spanTracerStub.Expect(
+                x => x.SendClientSpan(
+                    Arg<string>.Is.Equal(spanName.ToLower()),
+                    Arg<string>.Is.Equal(nextTraceProvider.TraceId),
+                    Arg<string>.Is.Equal(nextTraceProvider.ParentSpanId),
+                    Arg<string>.Is.Equal(nextTraceProvider.SpanId),
+                    Arg<string>.Is.Equal(clientServiceName),
+                    Arg<string>.Is.Anything)).Return(expectedSpan);
 
             var result = tracerClient.StartClientTrace(new Uri("https://" + clientServiceName + ".xyz.net:8000" + uriAbsolutePath), methodName);
 
@@ -334,10 +355,17 @@ namespace Medidata.ZipkinTracer.Core.Test
             var clientServiceName = "192.168.178.178";
             var uriAbsolutePath = "/object";
             var methodName = "GET";
-            var spanName = string.Format("{0} {1}", methodName, uriAbsolutePath);
+            var spanName = methodName;
 
             var expectedSpan = new Span();
-            spanTracerStub.Expect(x => x.SendClientSpan(Arg<string>.Is.Equal(spanName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Equal(clientServiceName))).Return(expectedSpan);
+            spanTracerStub.Expect(
+                x => x.SendClientSpan(
+                    Arg<string>.Is.Equal(spanName.ToLower()),
+                    Arg<string>.Is.Equal(nextTraceProvider.TraceId),
+                    Arg<string>.Is.Equal(nextTraceProvider.ParentSpanId),
+                    Arg<string>.Is.Equal(nextTraceProvider.SpanId),
+                    Arg<string>.Is.Equal(clientServiceName),
+                    Arg<string>.Is.Anything)).Return(expectedSpan);
 
             var result = tracerClient.StartClientTrace(new Uri("https://" + clientServiceName + ".xyz.net:8000" + uriAbsolutePath), methodName);
 
@@ -356,10 +384,17 @@ namespace Medidata.ZipkinTracer.Core.Test
             var clientServiceName = "abc-sandbox";
             var uriAbsolutePath = "/object";
             var methodName = "GET";
-            var spanName = string.Format("{0} {1}", methodName, uriAbsolutePath);
+            var spanName = methodName;
 
             var expectedSpan = new Span();
-            spanTracerStub.Expect(x => x.SendClientSpan(Arg<string>.Is.Equal(spanName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Equal(clientServiceName))).Return(expectedSpan);
+            spanTracerStub.Expect(
+                x => x.SendClientSpan(
+                    Arg<string>.Is.Equal(spanName.ToLower()),
+                    Arg<string>.Is.Equal(nextTraceProvider.TraceId),
+                    Arg<string>.Is.Equal(nextTraceProvider.ParentSpanId),
+                    Arg<string>.Is.Equal(nextTraceProvider.SpanId),
+                    Arg<string>.Is.Equal(clientServiceName),
+                    Arg<string>.Is.Anything)).Return(expectedSpan);
 
             var result = tracerClient.StartClientTrace(new Uri("https://" + clientServiceName + ".xyz.net:8000" + uriAbsolutePath), methodName);
 
@@ -376,9 +411,16 @@ namespace Medidata.ZipkinTracer.Core.Test
             var clientServiceName = "abc-sandbox";
             var uriAbsolutePath = "/object";
             var methodName = "GET";
-            var spanName = string.Format("{0} {1}", methodName, uriAbsolutePath);
+            var spanName = methodName;
 
-            spanTracerStub.Expect(x => x.SendClientSpan(Arg<string>.Is.Equal(spanName), Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Anything, Arg<string>.Is.Equal(clientServiceName))).Throw(new Exception());
+            spanTracerStub.Expect(
+                x => x.SendClientSpan(
+                    Arg<string>.Is.Equal(spanName.ToLower()),
+                    Arg<string>.Is.Anything,
+                    Arg<string>.Is.Anything,
+                    Arg<string>.Is.Anything,
+                    Arg<string>.Is.Equal(clientServiceName),
+                    Arg<string>.Is.Anything)).Throw(new Exception());
 
             var result = tracerClient.StartClientTrace(new Uri("https://" + clientServiceName + ".xyz.net:8000" + uriAbsolutePath), methodName);
 
@@ -480,7 +522,15 @@ namespace Medidata.ZipkinTracer.Core.Test
             spanCollectorBuilder.Expect(x => x.Build(Arg<Uri>.Is.Anything, Arg<int>.Is.Anything, Arg<ILog>.Is.Equal(logger))).Return(spanCollectorStub);
 
             traceProvider.Expect(x => x.TraceId).Return(fixture.Create<string>());
+            traceProvider.Expect(x => x.SpanId).Return(fixture.Create<string>());
+            traceProvider.Expect(x => x.ParentSpanId).Return(traceProvider.TraceId);
             traceProvider.Expect(x => x.IsSampled).Return(true);
+            
+            nextTraceProvider.Expect(x => x.TraceId).Return(fixture.Create<string>());
+            nextTraceProvider.Expect(x => x.SpanId).Return(fixture.Create<string>());
+            nextTraceProvider.Expect(x => x.ParentSpanId).Return(traceProvider.TraceId);
+            nextTraceProvider.Expect(x => x.IsSampled).Return(true);
+            traceProvider.Stub(x => x.GetNext()).Return(nextTraceProvider);
 
             IZipkinConfig zipkinConfigSetup = zipkinConfig;
             if (zipkinConfig == null)


### PR DESCRIPTION
@kenyamat @BPONTES @lschreck-mdsol @jcarres-mdsol 
This PR will improve the data for UI. It will create new span for client trace and add http.uri annotation

Specifics:
- delete absolute path after method name for span name value
- set to lower on method name for span name value to prevent bug in server about case issue
- updated binaryannotation to http.uri from redundant data(traceid,spanid,parentid)
- updated binaryannotation to string representation, http post json is expected to be in string format
- for client trace, getnext span for TraceId
- updated unit test
- bump zipkin assembly versions

Please review and merge. Thanks