### PR TITLE
[MCC-199419] Add domain config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Add the below additional configurations. Please verify these values and modify t
 
 ```
 <appSettings>
+  <add key="domain" value="ampridatvir-sandbox.xyz.com" />
   <add key="zipkinScribeServerName" value="zipkinvm.cloudapp.net" />
   <add key="zipkinScribeServerPort" value="9410" />
   <add key="zipkinServiceName" value="Name of your Service i.e. MyApplication" />
@@ -43,6 +44,7 @@ Add the below additional configurations. Please verify these values and modify t
   <add key="zipkinProxyType" value="Http" /> 
 </appSettings>
 ```
+	domain - host url for the host instance.
 
 	zipkinScribeServerName - the zipkin scribe/collector server name to connect to send the Spans
 

--- a/src/Medidata.ZipkinTracer.Core.Collector/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.3")]
-[assembly: AssemblyFileVersion("1.0.3")]
-[assembly: AssemblyInformationalVersion("1.0.3")]
+[assembly: AssemblyVersion("1.0.4")]
+[assembly: AssemblyFileVersion("1.0.4")]
+[assembly: AssemblyInformationalVersion("1.0.4")]
 [assembly: InternalsVisibleTo("Medidata.ZipkinTracer.Core.Collector.Test")]

--- a/src/Medidata.ZipkinTracer.Core.Collector/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2")]
-[assembly: AssemblyFileVersion("1.0.2")]
-[assembly: AssemblyInformationalVersion("1.0.2")]
+[assembly: AssemblyVersion("1.0.3")]
+[assembly: AssemblyFileVersion("1.0.3")]
+[assembly: AssemblyInformationalVersion("1.0.3")]
 [assembly: InternalsVisibleTo("Medidata.ZipkinTracer.Core.Collector.Test")]

--- a/src/Medidata.ZipkinTracer.Core/ITracerClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ITracerClient.cs
@@ -5,8 +5,8 @@ namespace Medidata.ZipkinTracer.Core
     public interface ITracerClient
     {
         Span StartServerTrace(Uri requestUri, string methodName);
-        Span StartClientTrace(Uri requestUri, string methodName);
+        Span StartClientTrace(Uri remoteUri, string methodName);
         void EndServerTrace(Span serverSpan);
-        void EndClientTrace(Span clientSpan);
+        void EndClientTrace(Span clientSpan, int statusCode);
     }
 }

--- a/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
@@ -9,6 +9,7 @@ namespace Medidata.ZipkinTracer.Core
         string SpanProcessorBatchSize { get; }
         string DontSampleListCsv { get; }
         string ZipkinSampleRate { get; }
+        string Domain { get; }
         List<string> GetNotToBeDisplayedDomainList();
     }
 }

--- a/src/Medidata.ZipkinTracer.Core/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.Core/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.3")]
-[assembly: AssemblyFileVersion("1.0.3")]
-[assembly: AssemblyInformationalVersion("1.0.3")]
+[assembly: AssemblyVersion("1.0.4")]
+[assembly: AssemblyFileVersion("1.0.4")]
+[assembly: AssemblyInformationalVersion("1.0.4")]
 [assembly: InternalsVisibleTo("Medidata.ZipkinTracer.Core.Test")]

--- a/src/Medidata.ZipkinTracer.Core/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.Core/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.4")]
-[assembly: AssemblyFileVersion("1.0.4")]
-[assembly: AssemblyInformationalVersion("1.0.4")]
+[assembly: AssemblyVersion("1.0.5")]
+[assembly: AssemblyFileVersion("1.0.5")]
+[assembly: AssemblyInformationalVersion("1.0.5")]
 [assembly: InternalsVisibleTo("Medidata.ZipkinTracer.Core.Test")]

--- a/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
@@ -35,7 +35,12 @@ namespace Medidata.ZipkinTracer.Core
                         int.Parse(zipkinConfig.SpanProcessorBatchSize),
                         logger);
 
-                    spanTracer = new SpanTracer(spanCollector, zipkinConfig.ServiceName, new ServiceEndpoint(), zipkinConfig.GetNotToBeDisplayedDomainList());
+                    spanTracer = new SpanTracer(
+                        spanCollector,
+                        new ServiceEndpoint(),
+                        zipkinConfig.GetNotToBeDisplayedDomainList(),
+                        zipkinConfig.Domain,
+                        zipkinConfig.ServiceName);
 
                     this.traceProvider = traceProvider;
                 }

--- a/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
-using System.Net;
 
 namespace Medidata.ZipkinTracer.Core
 {
@@ -31,6 +30,11 @@ namespace Medidata.ZipkinTracer.Core
         public string ZipkinSampleRate
         {
             get {  return ConfigurationManager.AppSettings["zipkinSampleRate"];}
+        }
+
+        public string Domain
+        {
+            get { return ConfigurationManager.AppSettings["domain"]; }
         }
 
         public List<string> GetNotToBeDisplayedDomainList()

--- a/src/Medidata.ZipkinTracer.HttpModule/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.HttpModule/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.3")]
-[assembly: AssemblyFileVersion("1.0.3")]
-[assembly: AssemblyInformationalVersion("1.0.3")]
+[assembly: AssemblyVersion("1.0.4")]
+[assembly: AssemblyFileVersion("1.0.4")]
+[assembly: AssemblyInformationalVersion("1.0.4")]

--- a/src/Medidata.ZipkinTracer.HttpModule/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.HttpModule/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.4")]
-[assembly: AssemblyFileVersion("1.0.4")]
-[assembly: AssemblyInformationalVersion("1.0.4")]
+[assembly: AssemblyVersion("1.0.5")]
+[assembly: AssemblyFileVersion("1.0.5")]
+[assembly: AssemblyInformationalVersion("1.0.5")]

--- a/tests/Medidata.ZipkinTracer.Core.Test/Medidata.ZipkinTracer.Core.Test.csproj
+++ b/tests/Medidata.ZipkinTracer.Core.Test/Medidata.ZipkinTracer.Core.Test.csproj
@@ -83,9 +83,9 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SpanTracerTests.cs" />
+    <Compile Include="ZipkinClientTests.cs" />
     <Compile Include="ZipkinConfigTests.cs" />
     <Compile Include="ZipkinEndpointTests.cs" />
-    <Compile Include="ZipkinClientTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Medidata.ZipkinTracer.Core.Collector\Medidata.ZipkinTracer.Core.Collector.csproj">

--- a/tests/Medidata.ZipkinTracer.Core.Test/SpanTracerTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/SpanTracerTests.cs
@@ -4,7 +4,7 @@ using Ploeh.AutoFixture;
 using Medidata.ZipkinTracer.Core.Collector;
 using Rhino.Mocks;
 using System.Linq;
-using System.Text;
+using System.Collections.Generic;
 using log4net;
 
 namespace Medidata.ZipkinTracer.Core.Test
@@ -16,6 +16,11 @@ namespace Medidata.ZipkinTracer.Core.Test
         private SpanCollector spanCollectorStub;
         private ServiceEndpoint zipkinEndpointStub;
         private ILog logger;
+        private IEnumerable<string> zipkinNotToBeDisplayedDomainList;
+        private string serverServiceName;
+        private string clientServiceName;
+        private short port;
+        private string api;
 
         [TestInitialize]
         public void Init()
@@ -24,27 +29,32 @@ namespace Medidata.ZipkinTracer.Core.Test
             logger = MockRepository.GenerateStub<ILog>();
             spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(new Uri("http://localhost"), 0, logger);
             zipkinEndpointStub = MockRepository.GenerateStub<ServiceEndpoint>();
+            zipkinNotToBeDisplayedDomainList = new List<string> {".xyz.net"};
+            serverServiceName = "xyz-sandbox";
+            clientServiceName = "abc-sandbox";
+            port = 42;
+            api = "/api/method1";
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void CTOR_WithNullSpanCollector()
         {
-            new SpanTracer(null, fixture.Create<string>(), zipkinEndpointStub);
+            new SpanTracer(null, fixture.Create<string>(), zipkinEndpointStub, null);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void CTOR_WithNullOrEmptyString()
         {
-            new SpanTracer(spanCollectorStub, null, zipkinEndpointStub);
+            new SpanTracer(spanCollectorStub, null, zipkinEndpointStub, null);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void CTOR_WithNullZipkinEndpoint()
         {
-            new SpanTracer(spanCollectorStub, fixture.Create<string>(), null);
+            new SpanTracer(spanCollectorStub, fixture.Create<string>(), null, null);
         }
 
         [TestMethod]
@@ -55,13 +65,14 @@ namespace Medidata.ZipkinTracer.Core.Test
             var traceId = fixture.Create<long>().ToString();
             var parentSpanId = fixture.Create<long>().ToString();
             var spanId = fixture.Create<long>().ToString();
-            var path = fixture.Create<long>().ToString();
+            var serverUri = new Uri("https://" + clientServiceName + ":" + port + api);
 
-            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub);
+            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub, zipkinNotToBeDisplayedDomainList);
 
-            zipkinEndpointStub.Expect(x => x.GetEndpoint(serviceName)).Return(new Endpoint() { Service_name = serviceName });
+            var localEndpoint = new Endpoint { Service_name = serverServiceName, Port = port };
+            zipkinEndpointStub.Expect(x => x.GetLocalEndpoint(Arg.Is(serviceName), Arg.Is(port))).Return(localEndpoint);
 
-            var resultSpan = spanTracer.ReceiveServerSpan(requestName, traceId, parentSpanId, spanId, path);
+            var resultSpan = spanTracer.ReceiveServerSpan(requestName, traceId, parentSpanId, spanId, serverUri);
 
             Assert.AreEqual(requestName, resultSpan.Name);
             Assert.AreEqual(Int64.Parse(traceId, System.Globalization.NumberStyles.HexNumber), resultSpan.Trace_id);
@@ -76,24 +87,23 @@ namespace Medidata.ZipkinTracer.Core.Test
             Assert.IsNotNull(annotation.Timestamp);
             Assert.IsNotNull(annotation.Host);
 
-            var endpoint = annotation.Host as Endpoint;
-            Assert.IsNotNull(endpoint);
-            Assert.AreEqual(serviceName, endpoint.Service_name);
+            Assert.AreEqual(localEndpoint, annotation.Host);
 
-            AssertBinaryAnnotations(resultSpan.Binary_annotations, path);
+            Assert.AreEqual(1, resultSpan.Binary_annotations.Count);
+            AssertBinaryAnnotations(resultSpan.Binary_annotations, "http.uri", serverUri.AbsolutePath);
         }
 
         [TestMethod]
         public void SendServerSpan()
         {
             var serviceName = fixture.Create<string>();
-            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub);
+            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub, zipkinNotToBeDisplayedDomainList);
 
             var endpoint = new Endpoint() { Service_name = serviceName };
-            var expectedSpan = new Span() { Annotations = new System.Collections.Generic.List<Annotation>() };
+            var expectedSpan = new Span() { Annotations = new List<Annotation>() };
             expectedSpan.Annotations.Add(new Annotation() { Host = endpoint, Value = zipkinCoreConstants.SERVER_RECV, Timestamp = 1 });
 
-            zipkinEndpointStub.Expect(x => x.GetEndpoint(serviceName)).Return(new Endpoint() { Service_name = serviceName });
+            zipkinEndpointStub.Expect(x => x.GetLocalEndpoint(serviceName)).Return(new Endpoint() { Service_name = serviceName });
 
             spanTracer.SendServerSpan(expectedSpan);
 
@@ -108,7 +118,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         public void SendServerSpan_NullSpan()
         {
             var serviceName = fixture.Create<string>();
-            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub);
+            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub, zipkinNotToBeDisplayedDomainList);
 
             spanTracer.SendServerSpan(null);
         }
@@ -118,7 +128,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         public void SendServerSpan_NullAnnotation()
         {
             var serviceName = fixture.Create<string>();
-            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub);
+            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub, zipkinNotToBeDisplayedDomainList);
 
             var expectedSpan = new Span();
 
@@ -130,9 +140,9 @@ namespace Medidata.ZipkinTracer.Core.Test
         public void SendServerSpan_InvalidAnnotation()
         {
             var serviceName = fixture.Create<string>();
-            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub);
+            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub, zipkinNotToBeDisplayedDomainList);
 
-            var expectedSpan = new Span() { Annotations = new System.Collections.Generic.List<Annotation>() };
+            var expectedSpan = new Span() { Annotations = new List<Annotation>() };
 
             spanTracer.SendServerSpan(expectedSpan);
         }
@@ -141,18 +151,21 @@ namespace Medidata.ZipkinTracer.Core.Test
         public void SendClientSpan()
         {
             var serviceName = fixture.Create<string>();
-            var clientServiceName = fixture.Create<string>();
             var requestName = fixture.Create<string>();
             var traceId = fixture.Create<long>().ToString();
             var parentSpanId = fixture.Create<long>().ToString();
             var spanId = fixture.Create<long>().ToString();
-            var path = fixture.Create<long>().ToString();
+            var serverUri = new Uri("https://" + clientServiceName + ":" + port + api);
 
-            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub);
+            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub, zipkinNotToBeDisplayedDomainList);
 
-            zipkinEndpointStub.Expect(x => x.GetEndpoint(clientServiceName)).Return(new Endpoint() { Service_name = clientServiceName });
+            var localEndpoint = new Endpoint {Service_name = serverServiceName};
+            zipkinEndpointStub.Expect(x => x.GetLocalEndpoint(Arg.Is(serviceName), Arg<short>.Is.Anything)).Return(localEndpoint);
+            var remoteEndpoint = new Endpoint { Service_name = clientServiceName };
+            zipkinEndpointStub.Expect(x => x.GetRemoteEndpoint(Arg.Is(serverUri), Arg.Is(clientServiceName))).Return(remoteEndpoint);
 
-            var resultSpan = spanTracer.SendClientSpan(requestName, traceId, parentSpanId, spanId, clientServiceName, path);
+            var resultSpan = spanTracer.SendClientSpan(requestName, traceId, parentSpanId, spanId, serverUri);
+
             Assert.AreEqual(requestName, resultSpan.Name);
             Assert.AreEqual(Int64.Parse(traceId, System.Globalization.NumberStyles.HexNumber), resultSpan.Trace_id);
             Assert.AreEqual(Int64.Parse(parentSpanId, System.Globalization.NumberStyles.HexNumber), resultSpan.Parent_id);
@@ -164,30 +177,84 @@ namespace Medidata.ZipkinTracer.Core.Test
             Assert.IsNotNull(annotation);
             Assert.AreEqual(zipkinCoreConstants.CLIENT_SEND, annotation.Value);
             Assert.IsNotNull(annotation.Timestamp);
-            Assert.IsNotNull(annotation.Host);
-            AssertBinaryAnnotations(resultSpan.Binary_annotations, path);
+            Assert.AreEqual(localEndpoint, annotation.Host);
+            
+            Assert.AreEqual(2, resultSpan.Binary_annotations.Count);
+            AssertBinaryAnnotations(resultSpan.Binary_annotations, "http.uri", serverUri.AbsolutePath);
+            AssertBinaryAnnotations(resultSpan.Binary_annotations, "sa", "1");
 
-            var endpoint = annotation.Host as Endpoint;
+            var endpoint = resultSpan.Binary_annotations[1].Host as Endpoint;
             Assert.IsNotNull(endpoint);
             Assert.AreEqual(clientServiceName, endpoint.Service_name);
+        }
+
+        [TestMethod]
+        public void SendClientSpanWithDomainUnderFilterList()
+        {
+            var serviceName = fixture.Create<string>();
+            var requestName = fixture.Create<string>();
+            var traceId = fixture.Create<long>().ToString();
+            var parentSpanId = fixture.Create<long>().ToString();
+            var spanId = fixture.Create<long>().ToString();
+            var serverUri = new Uri("https://" + clientServiceName + zipkinNotToBeDisplayedDomainList.First() + ":" + port + api);
+
+            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub, zipkinNotToBeDisplayedDomainList);
+
+            var localEndpoint = new Endpoint { Service_name = serverServiceName };
+            zipkinEndpointStub.Expect(x => x.GetLocalEndpoint(Arg.Is(serviceName), Arg<short>.Is.Anything)).Return(localEndpoint);
+            var remoteEndpoint = new Endpoint { Service_name = clientServiceName };
+            zipkinEndpointStub.Expect(x => x.GetRemoteEndpoint(Arg.Is(serverUri), Arg.Is(clientServiceName))).Return(remoteEndpoint);
+
+            var resultSpan = spanTracer.SendClientSpan(requestName, traceId, parentSpanId, spanId, serverUri);
+
+            var endpoint = resultSpan.Binary_annotations[1].Host as Endpoint;
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual(clientServiceName, endpoint.Service_name);
+        }
+
+        [TestMethod]
+        public void SendClientSpanWithDomainNotUnderFilterList()
+        {
+            var serviceName = fixture.Create<string>();
+            var requestName = fixture.Create<string>();
+            var traceId = fixture.Create<long>().ToString();
+            var parentSpanId = fixture.Create<long>().ToString();
+            var spanId = fixture.Create<long>().ToString();
+            var domain = ".hij.com";
+            var serverUri = new Uri("https://" + clientServiceName + domain + ":" + port + api);
+
+            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub, zipkinNotToBeDisplayedDomainList);
+
+            var localEndpoint = new Endpoint { Service_name = serverServiceName };
+            zipkinEndpointStub.Expect(x => x.GetLocalEndpoint(Arg.Is(serviceName), Arg<short>.Is.Anything)).Return(localEndpoint);
+            var remoteEndpoint = new Endpoint { Service_name = clientServiceName + domain };
+            zipkinEndpointStub.Expect(x => x.GetRemoteEndpoint(Arg.Is(serverUri), Arg.Is(clientServiceName + domain))).Return(remoteEndpoint);
+
+            var resultSpan = spanTracer.SendClientSpan(requestName, traceId, parentSpanId, spanId, serverUri);
+
+            var endpoint = resultSpan.Binary_annotations[1].Host as Endpoint;
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual(clientServiceName + domain, endpoint.Service_name);
         }
 
         [TestMethod]
         public void ReceiveClientSpan()
         {
             var serviceName = fixture.Create<string>();
-            var clientServiceName = fixture.Create<string>();
-            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub);
+            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub, zipkinNotToBeDisplayedDomainList);
             var endpoint = new Endpoint() { Service_name = clientServiceName };
+            var serverUri = new Uri("https://" + clientServiceName + ":" + port + api);
+            var returnCode = fixture.Create<short>();
             var expectedSpan = new Span()
             {
-                Annotations = new System.Collections.Generic.List<Annotation>()
+                Annotations = new List<Annotation>(),
+                Binary_annotations = new List<BinaryAnnotation>()
             };
             expectedSpan.Annotations.Add(new Annotation() { Host = endpoint, Value = zipkinCoreConstants.CLIENT_SEND, Timestamp = 1 });
 
-            zipkinEndpointStub.Expect(x => x.GetEndpoint(clientServiceName)).Return(endpoint);
+            zipkinEndpointStub.Expect(x => x.GetRemoteEndpoint(serverUri, serviceName)).Return(endpoint);
 
-            spanTracer.ReceiveClientSpan(expectedSpan);
+            spanTracer.ReceiveClientSpan(expectedSpan, returnCode);
 
             spanCollectorStub.AssertWasCalled(x => x.Collect(Arg<Span>.Matches(y =>
                     ValidateReceiveClientSpan(y, clientServiceName)
@@ -200,17 +267,18 @@ namespace Medidata.ZipkinTracer.Core.Test
         public void ReceiveClientSpan_NullAnnotation()
         {
             var serviceName = fixture.Create<string>();
-            var clientServiceName = fixture.Create<string>();
-            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub);
+            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub, zipkinNotToBeDisplayedDomainList);
             var endpoint = new Endpoint() { Service_name = clientServiceName };
+            var serverUri = new Uri("https://" + clientServiceName + ":" + port + api);
+            var returnCode = fixture.Create<short>();
             var expectedSpan = new Span()
             {
                 Annotations = null
             };
 
-            zipkinEndpointStub.Expect(x => x.GetEndpoint(clientServiceName)).Return(endpoint);
+            zipkinEndpointStub.Expect(x => x.GetRemoteEndpoint(serverUri, serviceName)).Return(endpoint);
 
-            spanTracer.ReceiveClientSpan(expectedSpan);
+            spanTracer.ReceiveClientSpan(expectedSpan, returnCode);
         }
 
         [TestMethod]
@@ -218,17 +286,18 @@ namespace Medidata.ZipkinTracer.Core.Test
         public void ReceiveClientSpan_EmptyAnnotationsList()
         {
             var serviceName = fixture.Create<string>();
-            var clientServiceName = fixture.Create<string>();
-            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub);
+            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub, zipkinNotToBeDisplayedDomainList);
             var endpoint = new Endpoint() { Service_name = clientServiceName };
+            var serverUri = new Uri("https://" + clientServiceName + ":" + port + api);
+            var returnCode = fixture.Create<short>();
             var expectedSpan = new Span()
             {
-                Annotations = new System.Collections.Generic.List<Annotation>()
+                Annotations = new List<Annotation>()
             };
 
-            zipkinEndpointStub.Expect(x => x.GetEndpoint(clientServiceName)).Return(endpoint);
+            zipkinEndpointStub.Expect(x => x.GetRemoteEndpoint(serverUri, serviceName)).Return(endpoint);
 
-            spanTracer.ReceiveClientSpan(expectedSpan);
+            spanTracer.ReceiveClientSpan(expectedSpan, returnCode);
         }
 
         private bool ValidateReceiveClientSpan(Span y, string serviceName)
@@ -269,11 +338,9 @@ namespace Medidata.ZipkinTracer.Core.Test
             return true;
         }
 
-        private void AssertBinaryAnnotations(System.Collections.Generic.List<BinaryAnnotation> list, string path)
+        private void AssertBinaryAnnotations(List<BinaryAnnotation> list, string key, string value)
         {
-            Assert.AreEqual(1, list.Count);
-
-            Assert.AreEqual(path, list.Where(x => x.Key.Equals("http.uri")).Select(x => x.Value).First());
+            Assert.AreEqual(value, list.Where(x => x.Key.Equals(key)).Select(x => x.Value).First());
         }
     }
 }

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Ploeh.AutoFixture;
 using Rhino.Mocks;
@@ -210,12 +209,13 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var uriHost = "https://www.x@y.com";
             var uriAbsolutePath = "/object";
             var methodName = "GET";
             var spanName = methodName;
+            var requestUri = new Uri(uriHost + uriAbsolutePath);
 
             var expectedSpan = new Span();
             spanTracerStub.Expect(
@@ -224,9 +224,9 @@ namespace Medidata.ZipkinTracer.Core.Test
                     Arg<string>.Is.Equal(traceProvider.TraceId),
                     Arg<string>.Is.Equal(traceProvider.ParentSpanId),
                     Arg<string>.Is.Equal(traceProvider.SpanId),
-                    Arg<string>.Is.Anything)).Return(expectedSpan);
+                    Arg<Uri>.Is.Equal(requestUri))).Return(expectedSpan);
 
-            var result = tracerClient.StartServerTrace(new Uri(uriHost + uriAbsolutePath), methodName);
+            var result = tracerClient.StartServerTrace(requestUri, methodName);
 
             Assert.AreEqual(expectedSpan, result);
         }
@@ -236,12 +236,13 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var uriHost = "https://www.x@y.com";
             var uriAbsolutePath = "/object";
             var methodName = "GET";
             var spanName = methodName;
+            var requestUri = new Uri(uriHost + uriAbsolutePath);
 
             spanTracerStub.Expect(
                 x => x.ReceiveServerSpan(
@@ -249,9 +250,9 @@ namespace Medidata.ZipkinTracer.Core.Test
                     Arg<string>.Is.Anything,
                     Arg<string>.Is.Anything,
                     Arg<string>.Is.Anything,
-                    Arg<string>.Is.Anything)).Throw(new Exception());
+                    Arg<Uri>.Is.Equal(requestUri))).Throw(new Exception());
 
-            var result = tracerClient.StartServerTrace(new Uri(uriHost + uriAbsolutePath), methodName);
+            var result = tracerClient.StartServerTrace(requestUri, methodName);
 
             Assert.IsNull(result);
         }
@@ -276,7 +277,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var serverSpan = new Span();
 
@@ -290,7 +291,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var serverSpan = new Span();
 
@@ -323,7 +324,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var clientServiceName = "abc-sandbox";
             var uriAbsolutePath = "/object";
@@ -337,8 +338,7 @@ namespace Medidata.ZipkinTracer.Core.Test
                     Arg<string>.Is.Equal(nextTraceProvider.TraceId),
                     Arg<string>.Is.Equal(nextTraceProvider.ParentSpanId),
                     Arg<string>.Is.Equal(nextTraceProvider.SpanId),
-                    Arg<string>.Is.Equal(clientServiceName),
-                    Arg<string>.Is.Anything)).Return(expectedSpan);
+                    Arg<Uri>.Is.Anything)).Return(expectedSpan);
 
             var result = tracerClient.StartClientTrace(new Uri("https://" + clientServiceName + ".xyz.net:8000" + uriAbsolutePath), methodName);
 
@@ -350,7 +350,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var clientServiceName = "192.168.178.178";
             var uriAbsolutePath = "/object";
@@ -364,8 +364,7 @@ namespace Medidata.ZipkinTracer.Core.Test
                     Arg<string>.Is.Equal(nextTraceProvider.TraceId),
                     Arg<string>.Is.Equal(nextTraceProvider.ParentSpanId),
                     Arg<string>.Is.Equal(nextTraceProvider.SpanId),
-                    Arg<string>.Is.Equal(clientServiceName),
-                    Arg<string>.Is.Anything)).Return(expectedSpan);
+                    Arg<Uri>.Is.Anything)).Return(expectedSpan);
 
             var result = tracerClient.StartClientTrace(new Uri("https://" + clientServiceName + ".xyz.net:8000" + uriAbsolutePath), methodName);
 
@@ -379,7 +378,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             zipkinConfig.Expect(x => x.GetNotToBeDisplayedDomainList()).Return(new List<string>() { ".abc.net", ".xyz.net" });
             var tracerClient = SetupZipkinClient(zipkinConfig);
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var clientServiceName = "abc-sandbox";
             var uriAbsolutePath = "/object";
@@ -393,8 +392,7 @@ namespace Medidata.ZipkinTracer.Core.Test
                     Arg<string>.Is.Equal(nextTraceProvider.TraceId),
                     Arg<string>.Is.Equal(nextTraceProvider.ParentSpanId),
                     Arg<string>.Is.Equal(nextTraceProvider.SpanId),
-                    Arg<string>.Is.Equal(clientServiceName),
-                    Arg<string>.Is.Anything)).Return(expectedSpan);
+                    Arg<Uri>.Is.Anything)).Return(expectedSpan);
 
             var result = tracerClient.StartClientTrace(new Uri("https://" + clientServiceName + ".xyz.net:8000" + uriAbsolutePath), methodName);
 
@@ -406,7 +404,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var clientServiceName = "abc-sandbox";
             var uriAbsolutePath = "/object";
@@ -419,24 +417,9 @@ namespace Medidata.ZipkinTracer.Core.Test
                     Arg<string>.Is.Anything,
                     Arg<string>.Is.Anything,
                     Arg<string>.Is.Anything,
-                    Arg<string>.Is.Equal(clientServiceName),
-                    Arg<string>.Is.Anything)).Throw(new Exception());
+                    Arg<Uri>.Is.Anything)).Throw(new Exception());
 
             var result = tracerClient.StartClientTrace(new Uri("https://" + clientServiceName + ".xyz.net:8000" + uriAbsolutePath), methodName);
-
-            Assert.IsNull(result);
-        }
-
-        [TestMethod]
-        public void StartClientSpan_InvalidClientServiceName()
-        {
-            var tracerClient = SetupZipkinClient();
-            var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
-            zipkinClient.spanTracer = spanTracerStub;
-            var methodName = "GET";
-
-            var result = tracerClient.StartClientTrace(null, methodName);
 
             Assert.IsNull(result);
         }
@@ -459,42 +442,45 @@ namespace Medidata.ZipkinTracer.Core.Test
         [TestMethod]
         public void EndClientSpan()
         {
+            var returnCode = fixture.Create<short>();
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var clientSpan = new Span();
 
-            tracerClient.EndClientTrace(clientSpan);
+            tracerClient.EndClientTrace(clientSpan, returnCode);
 
-            spanTracerStub.AssertWasCalled(x => x.ReceiveClientSpan(clientSpan));
+            spanTracerStub.AssertWasCalled(x => x.ReceiveClientSpan(clientSpan, returnCode));
         }
 
         [TestMethod]
         public void EndClientSpan_Exception()
         {
+            var returnCode = fixture.Create<short>();
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var clientSpan = new Span();
 
-            spanTracerStub.Expect(x => x.ReceiveClientSpan(clientSpan)).Throw(new Exception());
+            spanTracerStub.Expect(x => x.ReceiveClientSpan(clientSpan, returnCode)).Throw(new Exception());
 
-            tracerClient.EndClientTrace(clientSpan);
+            tracerClient.EndClientTrace(clientSpan, returnCode);
         }
 
         [TestMethod]
         public void EndClientSpan_NullClientTrace_DoesntThrow()
         {
+            var returnCode = fixture.Create<short>();
             var tracerClient = SetupZipkinClient();
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
 
             var called = false;
-            spanTracerStub.Stub(x => x.ReceiveClientSpan(Arg<Span>.Is.Anything))
+            spanTracerStub.Stub(x => x.ReceiveClientSpan(Arg<Span>.Is.Anything, Arg<short>.Is.Equal(returnCode)))
                 .WhenCalled(x => { called = true; });
 
-            tracerClient.EndClientTrace(null);
+            tracerClient.EndClientTrace(null, returnCode);
 
             Assert.IsFalse(called);
         }
@@ -502,16 +488,17 @@ namespace Medidata.ZipkinTracer.Core.Test
         [TestMethod]
         public void EndClientSpan_IsTraceOnIsFalse_DoesntThrow()
         {
+            var returnCode = fixture.Create<short>();
             var tracerClient = SetupZipkinClient();
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
             var zipkinClient = (ZipkinClient)tracerClient;
             zipkinClient.isTraceOn = false;
 
             var called = false;
-            spanTracerStub.Stub(x => x.ReceiveClientSpan(Arg<Span>.Is.Anything))
+            spanTracerStub.Stub(x => x.ReceiveClientSpan(Arg<Span>.Is.Anything, Arg<short>.Is.Equal(returnCode)))
                 .WhenCalled(x => { called = true; });
 
-            tracerClient.EndClientTrace(new Span());
+            tracerClient.EndClientTrace(new Span(), returnCode);
 
             Assert.IsFalse(called);
         }

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
@@ -209,7 +209,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var uriHost = "https://www.x@y.com";
             var uriAbsolutePath = "/object";
@@ -236,7 +236,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var uriHost = "https://www.x@y.com";
             var uriAbsolutePath = "/object";
@@ -277,7 +277,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var serverSpan = new Span();
 
@@ -291,7 +291,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var serverSpan = new Span();
 
@@ -324,7 +324,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var clientServiceName = "abc-sandbox";
             var uriAbsolutePath = "/object";
@@ -350,7 +350,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var clientServiceName = "192.168.178.178";
             var uriAbsolutePath = "/object";
@@ -378,7 +378,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             zipkinConfig.Expect(x => x.GetNotToBeDisplayedDomainList()).Return(new List<string>() { ".abc.net", ".xyz.net" });
             var tracerClient = SetupZipkinClient(zipkinConfig);
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var clientServiceName = "abc-sandbox";
             var uriAbsolutePath = "/object";
@@ -404,7 +404,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var clientServiceName = "abc-sandbox";
             var uriAbsolutePath = "/object";
@@ -445,7 +445,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             var returnCode = fixture.Create<short>();
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var clientSpan = new Span();
 
@@ -460,7 +460,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             var returnCode = fixture.Create<short>();
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
             zipkinClient.spanTracer = spanTracerStub;
             var clientSpan = new Span();
 
@@ -474,7 +474,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var returnCode = fixture.Create<short>();
             var tracerClient = SetupZipkinClient();
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
 
             var called = false;
             spanTracerStub.Stub(x => x.ReceiveClientSpan(Arg<Span>.Is.Anything, Arg<short>.Is.Equal(returnCode)))
@@ -490,7 +490,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var returnCode = fixture.Create<short>();
             var tracerClient = SetupZipkinClient();
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
             var zipkinClient = (ZipkinClient)tracerClient;
             zipkinClient.isTraceOn = false;
 

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinEndpointTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinEndpointTests.cs
@@ -16,12 +16,27 @@ namespace Medidata.ZipkinTracer.Core.Test
         }
 
         [TestMethod]
-        public void GetEndpoint()
+        public void GetLocalEndpoint()
         {
             var serviceName = fixture.Create<string>();
 
             var zipkinEndpoint = new ServiceEndpoint();
-            var endpoint = zipkinEndpoint.GetEndpoint(serviceName);
+            var endpoint = zipkinEndpoint.GetLocalEndpoint(serviceName);
+
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual(serviceName, endpoint.Service_name);
+            Assert.IsNotNull(endpoint.Ipv4);
+            Assert.IsNotNull(endpoint.Port);
+        }
+
+        [TestMethod]
+        public void GetRemoteEndpoint()
+        {
+            var remoteUri = new Uri("http://localhost");
+            var serviceName = fixture.Create<string>();
+
+            var zipkinEndpoint = new ServiceEndpoint();
+            var endpoint = zipkinEndpoint.GetRemoteEndpoint(remoteUri, serviceName);
 
             Assert.IsNotNull(endpoint);
             Assert.AreEqual(serviceName, endpoint.Service_name);


### PR DESCRIPTION
@kenyamat @lschreck-mdsol @cabbott @BPONTES @jcarres-mdsol 

This is in relation to the ruby implementation: https://mdsol.jiveon.com/community/research-development/rd-guilds/architecture-guild/projects/monitoring-and-health/blog/2015/12/08/unifying-caller-and-callee-names-on-zipkin
This PR is about adding domain config to be used as service name.
if (domain config is not null or empty) 
    use config.Domain
else 
   use config.ServiceName
Please review

Thanks,
Brent