### PR TITLE
[MCC-202655] Local Tracing for Arbitrary Events

### DIFF
--- a/src/Medidata.ZipkinTracer.Core/ITracerClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ITracerClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace Medidata.ZipkinTracer.Core
 {
@@ -8,5 +9,7 @@ namespace Medidata.ZipkinTracer.Core
         Span StartClientTrace(Uri remoteUri, string methodName);
         void EndServerTrace(Span serverSpan);
         void EndClientTrace(Span clientSpan, int statusCode);
+        void Record(Span span, [CallerMemberName] string value = null);
+        void RecordBinary<T>(Span span, string key, T value);
     }
 }

--- a/src/Medidata.ZipkinTracer.Core/Medidata.ZipkinTracer.Core.nuspec
+++ b/src/Medidata.ZipkinTracer.Core/Medidata.ZipkinTracer.Core.nuspec
@@ -20,6 +20,6 @@
     </references>
   </metadata>
   <files>
-    <file src="\bin\Release\Medidata.ZipkinTracer.Core.Collector.dll" target="lib\net45" />
+    <file src="\bin\$ConfigurationName$\Medidata.ZipkinTracer.Core.Collector.dll" target="lib\net45" />
   </files>
 </package>

--- a/src/Medidata.ZipkinTracer.Core/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.Core/Properties/AssemblyInfo.cs
@@ -7,12 +7,17 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Medidata.ZipkinTracer.Core")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Medidata Solutions Inc")]
+[assembly: AssemblyCompany("Medidata Solutions, Inc.")]
 [assembly: AssemblyProduct("Medidata.ZipkinTracer.Core")]
-[assembly: AssemblyCopyright("Copyright © Medidata Solutions Inc 2015")]
+[assembly: AssemblyCopyright("Copyright © Medidata Solutions, Inc. 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+
+#if DEBUG
+[assembly: AssemblyConfiguration("Debug")]
+#else
+[assembly: AssemblyConfiguration("Release")]
+#endif
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
@@ -32,7 +37,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.5")]
-[assembly: AssemblyFileVersion("1.0.5")]
-[assembly: AssemblyInformationalVersion("1.0.5")]
+[assembly: AssemblyVersion("1.1.0")]
+[assembly: AssemblyFileVersion("1.1.0")]
+[assembly: AssemblyInformationalVersion("1.1.0")]
 [assembly: InternalsVisibleTo("Medidata.ZipkinTracer.Core.Test")]

--- a/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
@@ -26,83 +26,83 @@ namespace Medidata.ZipkinTracer.Core
             if (!isTraceOn)
                 return;
 
-                try
-                {
-                    spanCollector = spanCollectorBuilder.Build(
-                        new Uri(zipkinConfig.ZipkinBaseUri),
-                        int.Parse(zipkinConfig.SpanProcessorBatchSize),
-                        logger);
+            try
+            {
+                spanCollector = spanCollectorBuilder.Build(
+                    new Uri(zipkinConfig.ZipkinBaseUri),
+                    int.Parse(zipkinConfig.SpanProcessorBatchSize),
+                    logger);
 
-                    spanTracer = new SpanTracer(
-                        spanCollector,
-                        new ServiceEndpoint(),
-                        zipkinConfig.GetNotToBeDisplayedDomainList(),
-                        zipkinConfig.Domain,
-                        zipkinConfig.ServiceName);
+                spanTracer = new SpanTracer(
+                    spanCollector,
+                    new ServiceEndpoint(),
+                    zipkinConfig.GetNotToBeDisplayedDomainList(),
+                    zipkinConfig.Domain,
+                    zipkinConfig.ServiceName);
 
-                    this.traceProvider = traceProvider;
-                }
-                catch (Exception ex)
-                {
-                    logger.Error("Error Building Zipkin Client Provider", ex);
-                    isTraceOn = false;
-                }
+                this.traceProvider = traceProvider;
             }
+            catch (Exception ex)
+            {
+                logger.Error("Error Building Zipkin Client Provider", ex);
+                isTraceOn = false;
+            }
+        }
 
         public Span StartClientTrace(Uri remoteUri, string methodName)
         {
             if (!isTraceOn)
                 return null;
 
-                try
-                {
-                    var nextTrace = traceProvider.GetNext();
-                    return spanTracer.SendClientSpan(
-                        methodName.ToLower(),
-                        nextTrace.TraceId,
-                        nextTrace.ParentSpanId,
-                        nextTrace.SpanId,
-                        remoteUri);
-                }
-                catch (Exception ex)
-                {
-                    logger.Error("Error Starting Client Trace", ex);
-                return null;
-                }
+            try
+            {
+                var nextTrace = traceProvider.GetNext();
+                return spanTracer.SendClientSpan(
+                    methodName.ToLower(),
+                    nextTrace.TraceId,
+                    nextTrace.ParentSpanId,
+                    nextTrace.SpanId,
+                    remoteUri);
             }
+            catch (Exception ex)
+            {
+                logger.Error("Error Starting Client Trace", ex);
+                return null;
+            }
+        }
 
         public void EndClientTrace(Span clientSpan, int statusCode)
         {
             if (!isTraceOn)
                 return;
 
-                try
-                {
-                    spanTracer.ReceiveClientSpan(clientSpan, statusCode);
-                }
-                catch (Exception ex)
-                {
-                    logger.Error("Error Ending Client Trace", ex);
-                }
+            try
+            {
+                spanTracer.ReceiveClientSpan(clientSpan, statusCode);
             }
+            catch (Exception ex)
+            {
+                logger.Error("Error Ending Client Trace", ex);
+            }
+        }
 
         public Span StartServerTrace(Uri requestUri, string methodName)
         {
             if (!isTraceOn)
                 return null;
 
-                try
-                {
-                    return spanTracer.ReceiveServerSpan(
-                        methodName.ToLower(),
-                        traceProvider.TraceId,
-                        traceProvider.ParentSpanId,
-                        traceProvider.SpanId,
-                        requestUri);
-                }
-                catch (Exception ex)
-                {
-                    logger.Error("Error Starting Server Trace", ex);
+            try
+            {
+                return spanTracer.ReceiveServerSpan(
+                    methodName.ToLower(),
+                    traceProvider.TraceId,
+                    traceProvider.ParentSpanId,
+                    traceProvider.SpanId,
+                    requestUri);
+            }
+            catch (Exception ex)
+            {
+                logger.Error("Error Starting Server Trace", ex);
                 return null;
             }
         }
@@ -112,14 +112,14 @@ namespace Medidata.ZipkinTracer.Core
             if (!isTraceOn)
                 return;
 
-                try
-                {
-                    spanTracer.SendServerSpan(serverSpan);
-                }
-                catch (Exception ex)
-                {
-                    logger.Error("Error Ending Server Trace", ex);
-                }
+            try
+            {
+                spanTracer.SendServerSpan(serverSpan);
+            }
+            catch (Exception ex)
+            {
+                logger.Error("Error Ending Server Trace", ex);
+            }
         }
 
         /// <summary>

--- a/tests/Medidata.ZipkinTracer.Core.Test/Medidata.ZipkinTracer.Core.Test.csproj
+++ b/tests/Medidata.ZipkinTracer.Core.Test/Medidata.ZipkinTracer.Core.Test.csproj
@@ -45,6 +45,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Medidata.CrossApplicationTracer.1.0.0.8\lib\net40\Medidata.CrossApplicationTracer.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/tests/Medidata.ZipkinTracer.Core.Test/SpanTracerTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/SpanTracerTests.cs
@@ -354,7 +354,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             var expectedDescription = "Description";
             var expectedSpan = new Span() { Annotations = new List<Annotation>() };
             var serviceName = fixture.Create<string>();
-            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub, zipkinNotToBeDisplayedDomainList);
+            var spanTracer = new SpanTracer(spanCollectorStub, zipkinEndpointStub, zipkinNotToBeDisplayedDomainList, null, serviceName);
 
             // Act
             spanTracer.Record(expectedSpan, expectedDescription);
@@ -384,7 +384,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             };
 
             var serviceName = fixture.Create<string>();
-            var spanTracer = new SpanTracer(spanCollectorStub, serviceName, zipkinEndpointStub, zipkinNotToBeDisplayedDomainList);
+            var spanTracer = new SpanTracer(spanCollectorStub, zipkinEndpointStub, zipkinNotToBeDisplayedDomainList, null, serviceName);
 
             foreach (var testValue in testValues)
             {

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
@@ -6,6 +6,8 @@ using Rhino.Mocks;
 using Medidata.ZipkinTracer.Core.Collector;
 using Medidata.CrossApplicationTracer;
 using log4net;
+using System.Linq;
+using System.Diagnostics;
 
 namespace Medidata.ZipkinTracer.Core.Test
 {
@@ -501,6 +503,70 @@ namespace Medidata.ZipkinTracer.Core.Test
             tracerClient.EndClientTrace(new Span(), returnCode);
 
             Assert.IsFalse(called);
+        }
+
+        [TestMethod]
+        [TestCategory("TraceRecordTests")]
+        public void Record_IsTraceOnIsFalse_DoesNotAddAnnotation()
+        {
+            // Arrange
+            var tracerClient = SetupZipkinClient();
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            var zipkinClient = (ZipkinClient)tracerClient;
+            zipkinClient.isTraceOn = false;
+
+            var testSpan = new Span() { Annotations = new List<Annotation>() };
+
+            // Act
+            tracerClient.Record(testSpan, "irrelevant");
+
+            // Assert
+            Assert.AreEqual(0, testSpan.Annotations.Count, "There are annotations but the trace is off.");
+        }
+
+        [TestMethod]
+        [TestCategory("TraceRecordTests")]
+        public void Record_WithoutValue_AddsAnnotationWithCallerName()
+        {
+            // Arrange
+            var callerMemberName = new StackTrace().GetFrame(0).GetMethod().Name;
+            var tracerClient = SetupZipkinClient();
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            var zipkinClient = (ZipkinClient)tracerClient;
+            zipkinClient.isTraceOn = true;
+
+            var testSpan = new Span() { Annotations = new List<Annotation>() };
+
+            // Act
+            tracerClient.Record(testSpan);
+
+            // Assert
+            Assert.AreEqual(1, testSpan.Annotations.Count, "There is not exactly one annotation added.");
+            Assert.IsNotNull(
+                testSpan.Annotations.SingleOrDefault(a => a.Value == callerMemberName),
+                "The record with the caller name is not found in the Annotations."
+            );
+        }
+
+        [TestMethod]
+        [TestCategory("TraceRecordTests")]
+        public void RecordBinary_IsTraceOnIsFalse_DoesNotAddBinaryAnnotation()
+        {
+            // Arrange
+            var keyName = "TestKey";
+            var testValue = "Some Value";
+            var tracerClient = SetupZipkinClient();
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            var zipkinClient = (ZipkinClient)tracerClient;
+            zipkinClient.isTraceOn = false;
+
+            var testSpan = new Span() { Binary_annotations = new List<BinaryAnnotation>() };
+
+            // Act
+            tracerClient.RecordBinary(testSpan, keyName, testValue);
+
+            // Assert
+            Assert.AreEqual(0, testSpan.Binary_annotations.Count, "There are annotations but the trace is off.");
         }
 
         private ITracerClient SetupZipkinClient(IZipkinConfig zipkinConfig = null)

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
@@ -511,7 +511,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             // Arrange
             var tracerClient = SetupZipkinClient();
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
             var zipkinClient = (ZipkinClient)tracerClient;
             zipkinClient.isTraceOn = false;
 
@@ -531,7 +531,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             // Arrange
             var callerMemberName = new StackTrace().GetFrame(0).GetMethod().Name;
             var tracerClient = SetupZipkinClient();
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
             var zipkinClient = (ZipkinClient)tracerClient;
             zipkinClient.isTraceOn = true;
 
@@ -556,7 +556,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             var keyName = "TestKey";
             var testValue = "Some Value";
             var tracerClient = SetupZipkinClient();
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, fixture.Create<string>(), MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>());
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
             var zipkinClient = (ZipkinClient)tracerClient;
             zipkinClient.isTraceOn = false;
 

--- a/tests/TestWebApp/TestWebApp.csproj
+++ b/tests/TestWebApp/TestWebApp.csproj
@@ -21,6 +21,7 @@
     <IISExpressUseClassicPipelineMode />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -40,12 +41,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BouncyCastle.Crypto">
-      <HintPath>..\packages\BouncyCastle.1.7.0\lib\Net40-Client\BouncyCastle.Crypto.dll</HintPath>
-    </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+      <HintPath>..\..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json">
@@ -74,7 +72,9 @@
   <ItemGroup>
     <Content Include="appsettings.config" />
     <Content Include="Global.asax" />
-    <Content Include="packages.config" />
+    <Content Include="packages.config">
+      <SubType>Designer</SubType>
+    </Content>
     <Content Include="appsettings.template.config" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>

--- a/tests/TestWebApp/packages.config
+++ b/tests/TestWebApp/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BouncyCastle" version="1.7.0" targetFramework="net451" />
   <package id="log4net" version="2.0.3" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
@bvillanueva-mdsol @kenyamat @jcarres-mdsol This PR implements a tracing mechanism for being able to trace local events related to a request.

The concept is the following:
- The client creates a trace which will result an initialized Span
- Calling the newly added ZipkinClient.Record method With the previously initialized span the client is able to save a custom annotation in the current span with the timestamp of the calling
  - For a bonus if there is no value provided for the annotation, the tracer will record the caller method's name as the annotation value
- Another option is to call the ZipkinClient.RecordBinary method which will add a binary annotation to the current span (this can be used to record some general information regarding the context and environment)

Please note that I used some new features of the C# 6.0 (e.g. null-conditional operator, interpolated strings etc.) therefore it is highly recommended to use Visual Studio 2015 for development and build purposes from now on.

Please review and merge it, then I will create and publish the NuGet package.

fyi @cabbott @BPONTES @jfeltesse-mdsol 