### PR TITLE
[MCC-202655] Add Local Component Tracing with the 'lc' annotation type

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ using (var client = new HttpClient())
 
 In case of the `ZipkinClient.Record()` method, the second parameter(`value`) can be omitted during the call, in that case the caller member name (method, property etc.) will get recorded.
 
+#### Recording a local component
+With the `RecordLocalComponent()` method of the client a local component (or information) can be recorded for the current trace. This will result an additional binary annotation with the 'lc' key (LOCAL_COMPONENT) and a custom value.
+
 ## Contributors
 ZipkinTracer is (c) Medidata Solutions Worldwide and owned by its major contributors:
 * Tomoko Kwan

--- a/src/Medidata.ZipkinTracer.Core.Collector/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/Properties/AssemblyInfo.cs
@@ -7,12 +7,17 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Medidata.ZipkinTracer.Core.Collector")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Medidata Solutions Inc")]
+[assembly: AssemblyCompany("Medidata Solutions, Inc.")]
 [assembly: AssemblyProduct("Medidata.ZipkinTracer.Core.Collector")]
-[assembly: AssemblyCopyright("Copyright © Medidata Solutions Inc 2014")]
+[assembly: AssemblyCopyright("Copyright © Medidata Solutions, Inc. 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+
+#if DEBUG
+[assembly: AssemblyConfiguration("Debug")]
+#else
+[assembly: AssemblyConfiguration("Release")]
+#endif
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
@@ -32,7 +37,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.4")]
-[assembly: AssemblyFileVersion("1.0.4")]
-[assembly: AssemblyInformationalVersion("1.0.4")]
+[assembly: AssemblyVersion("1.2.0")]
+[assembly: AssemblyFileVersion("1.2.0")]
+[assembly: AssemblyInformationalVersion("1.2.0")]
 [assembly: InternalsVisibleTo("Medidata.ZipkinTracer.Core.Collector.Test")]

--- a/src/Medidata.ZipkinTracer.Core.Collector/thrift/gen-sharp/zipkinCore.Constants.cs
+++ b/src/Medidata.ZipkinTracer.Core.Collector/thrift/gen-sharp/zipkinCore.Constants.cs
@@ -4,19 +4,12 @@
  * DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
  *  @generated
  */
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Text;
-using System.IO;
-using Thrift;
-using Thrift.Collections;
-using System.Runtime.Serialization;
 
 public static class zipkinCoreConstants
 {
-  public static string CLIENT_SEND = "cs";
-  public static string CLIENT_RECV = "cr";
-  public static string SERVER_SEND = "ss";
-  public static string SERVER_RECV = "sr";
+    public static string CLIENT_SEND = "cs";
+    public static string CLIENT_RECV = "cr";
+    public static string SERVER_SEND = "ss";
+    public static string SERVER_RECV = "sr";
+    public static string LOCAL_COMPONENT = "lc";
 }

--- a/src/Medidata.ZipkinTracer.Core/ITracerClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ITracerClient.cs
@@ -11,5 +11,6 @@ namespace Medidata.ZipkinTracer.Core
         void EndClientTrace(Span clientSpan, int statusCode);
         void Record(Span span, [CallerMemberName] string value = null);
         void RecordBinary<T>(Span span, string key, T value);
+        void RecordLocalComponent(Span span, string value);
     }
 }

--- a/src/Medidata.ZipkinTracer.Core/Properties/AssemblyInfo.cs
+++ b/src/Medidata.ZipkinTracer.Core/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0")]
-[assembly: AssemblyFileVersion("1.1.0")]
-[assembly: AssemblyInformationalVersion("1.1.0")]
+[assembly: AssemblyVersion("1.2.0")]
+[assembly: AssemblyFileVersion("1.2.0")]
+[assembly: AssemblyInformationalVersion("1.2.0")]
 [assembly: InternalsVisibleTo("Medidata.ZipkinTracer.Core.Test")]

--- a/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
@@ -172,6 +172,26 @@ namespace Medidata.ZipkinTracer.Core
             }
         }
 
+        /// <summary>
+        /// Records a local component annotation in the span.
+        /// </summary>
+        /// <param name="span">The span where the annotation will be recorded.</param>
+        /// <param name="value">The value of the local trace to be recorder.</param>
+        public void RecordLocalComponent(Span span, string value)
+        {
+            if (!isTraceOn)
+                return;
+
+            try
+            {
+                spanTracer.RecordBinary(span, zipkinCoreConstants.LOCAL_COMPONENT, value);
+            }
+            catch (Exception ex)
+            {
+                logger.Error($"Error recording local trace (value: {value})", ex);
+            }
+        }
+
         public void ShutDown()
         {
             if (spanCollector != null)

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
@@ -569,6 +569,48 @@ namespace Medidata.ZipkinTracer.Core.Test
             Assert.AreEqual(0, testSpan.Binary_annotations.Count, "There are annotations but the trace is off.");
         }
 
+        [TestMethod]
+        [TestCategory("TraceRecordTests")]
+        public void RecordLocalComponent_WithNotNullValue_AddsLocalComponentAnnotation()
+        {
+            // Arrange
+            var testValue = "Some Value";
+            var tracerClient = SetupZipkinClient();
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            var zipkinClient = (ZipkinClient)tracerClient;
+            zipkinClient.isTraceOn = true;
+
+            var testSpan = new Span() { Binary_annotations = new List<BinaryAnnotation>() };
+
+            // Act
+            tracerClient.RecordLocalComponent(testSpan, testValue);
+
+            // Assert
+            var annotation = testSpan.Binary_annotations.SingleOrDefault(a => a.Key == zipkinCoreConstants.LOCAL_COMPONENT);
+            Assert.IsNotNull(annotation, "There is no local trace annotation in the binary annotations.");
+            Assert.AreEqual(testValue, annotation.Value, "The local component annotation value is not correct.");
+        }
+
+        [TestMethod]
+        [TestCategory("TraceRecordTests")]
+        public void RecordLocalComponent_IsTraceOnIsFalse_DoesNotAddLocalComponentAnnotation()
+        {
+            // Arrange
+            var testValue = "Some Value";
+            var tracerClient = SetupZipkinClient();
+            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            var zipkinClient = (ZipkinClient)tracerClient;
+            zipkinClient.isTraceOn = false;
+
+            var testSpan = new Span() { Binary_annotations = new List<BinaryAnnotation>() };
+
+            // Act
+            tracerClient.RecordBinary(testSpan, zipkinCoreConstants.LOCAL_COMPONENT, testValue);
+
+            // Assert
+            Assert.AreEqual(0, testSpan.Binary_annotations.Count, "There are annotations but the trace is off.");
+        }
+
         private ITracerClient SetupZipkinClient(IZipkinConfig zipkinConfig = null)
         {
             spanCollectorStub = MockRepository.GenerateStub<SpanCollector>(new Uri("http://localhost"), 0, logger);

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
@@ -211,7 +211,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
             zipkinClient.spanTracer = spanTracerStub;
             var uriHost = "https://www.x@y.com";
             var uriAbsolutePath = "/object";
@@ -238,7 +238,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
             zipkinClient.spanTracer = spanTracerStub;
             var uriHost = "https://www.x@y.com";
             var uriAbsolutePath = "/object";
@@ -279,7 +279,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
             zipkinClient.spanTracer = spanTracerStub;
             var serverSpan = new Span();
 
@@ -293,7 +293,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
             zipkinClient.spanTracer = spanTracerStub;
             var serverSpan = new Span();
 
@@ -326,7 +326,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
             zipkinClient.spanTracer = spanTracerStub;
             var clientServiceName = "abc-sandbox";
             var uriAbsolutePath = "/object";
@@ -352,7 +352,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
             zipkinClient.spanTracer = spanTracerStub;
             var clientServiceName = "192.168.178.178";
             var uriAbsolutePath = "/object";
@@ -380,7 +380,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             zipkinConfig.Expect(x => x.GetNotToBeDisplayedDomainList()).Return(new List<string>() { ".abc.net", ".xyz.net" });
             var tracerClient = SetupZipkinClient(zipkinConfig);
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
             zipkinClient.spanTracer = spanTracerStub;
             var clientServiceName = "abc-sandbox";
             var uriAbsolutePath = "/object";
@@ -406,7 +406,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
             zipkinClient.spanTracer = spanTracerStub;
             var clientServiceName = "abc-sandbox";
             var uriAbsolutePath = "/object";
@@ -447,7 +447,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             var returnCode = fixture.Create<short>();
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
             zipkinClient.spanTracer = spanTracerStub;
             var clientSpan = new Span();
 
@@ -462,7 +462,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             var returnCode = fixture.Create<short>();
             var tracerClient = SetupZipkinClient();
             var zipkinClient = (ZipkinClient)tracerClient;
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
             zipkinClient.spanTracer = spanTracerStub;
             var clientSpan = new Span();
 
@@ -476,7 +476,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var returnCode = fixture.Create<short>();
             var tracerClient = SetupZipkinClient();
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
 
             var called = false;
             spanTracerStub.Stub(x => x.ReceiveClientSpan(Arg<Span>.Is.Anything, Arg<short>.Is.Equal(returnCode)))
@@ -492,7 +492,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             var returnCode = fixture.Create<short>();
             var tracerClient = SetupZipkinClient();
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
             var zipkinClient = (ZipkinClient)tracerClient;
             zipkinClient.isTraceOn = false;
 
@@ -511,7 +511,7 @@ namespace Medidata.ZipkinTracer.Core.Test
         {
             // Arrange
             var tracerClient = SetupZipkinClient();
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
             var zipkinClient = (ZipkinClient)tracerClient;
             zipkinClient.isTraceOn = false;
 
@@ -531,7 +531,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             // Arrange
             var callerMemberName = new StackTrace().GetFrame(0).GetMethod().Name;
             var tracerClient = SetupZipkinClient();
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
             var zipkinClient = (ZipkinClient)tracerClient;
             zipkinClient.isTraceOn = true;
 
@@ -556,7 +556,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             var keyName = "TestKey";
             var testValue = "Some Value";
             var tracerClient = SetupZipkinClient();
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
             var zipkinClient = (ZipkinClient)tracerClient;
             zipkinClient.isTraceOn = false;
 
@@ -576,7 +576,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             // Arrange
             var testValue = "Some Value";
             var tracerClient = SetupZipkinClient();
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
             var zipkinClient = (ZipkinClient)tracerClient;
             zipkinClient.isTraceOn = true;
 
@@ -598,7 +598,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             // Arrange
             var testValue = "Some Value";
             var tracerClient = SetupZipkinClient();
-            spanTracerStub = MockRepository.GenerateStub<SpanTracer>(spanCollectorStub, MockRepository.GenerateStub<ServiceEndpoint>(), new List<string>(), fixture.Create<string>(), fixture.Create<string>());
+            spanTracerStub = GetSpanTracerStub();
             var zipkinClient = (ZipkinClient)tracerClient;
             zipkinClient.isTraceOn = false;
 
@@ -658,6 +658,18 @@ namespace Medidata.ZipkinTracer.Core.Test
             zipkinConfigStub.Expect(x => x.ZipkinSampleRate).Return(zipkinSampleRate);
             zipkinConfigStub.Expect(x => x.GetNotToBeDisplayedDomainList()).Return(domainList);
             return zipkinConfigStub;
+        }
+
+        private SpanTracer GetSpanTracerStub()
+        {
+            return
+                MockRepository.GenerateStub<SpanTracer>(
+                    spanCollectorStub,
+                    MockRepository.GenerateStub<ServiceEndpoint>(),
+                    new List<string>(),
+                    fixture.Create<string>(),
+                    fixture.Create<string>()
+                );
         }
     }
 }


### PR DESCRIPTION
@bvillanueva-mdsol @jcarres-mdsol @kenyamat This is the extension of the PR #72 with the 'lc' annotation type. It basically adds a new binary annotation with the predefined 'lc' key and a custom value.

Please review and merge it if you will. Then I will generate and publish the new NuGet package.

fyi @cabbott @BPONTES @jfeltesse-mdsol @ykitamura-mdsol 