### PR TITLE
[MCC-212633][Housekeeping] change property name for bypass mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This will happen if :
 ## Configurations
 Please use `ZipkinConig` class to configure the module and verify these values and modify them according to your service/environment.
 
-- `BypassMode` - false: enable ZipkinMiddleware/ZipkinMessageHandler, enable: disable ZipkinMiddleware/ZipkinMessageHandler.
+- `BypassMode` - **false**: enable ZipkinMiddleware/ZipkinMessageHandler, **true**: disable ZipkinMiddleware/ZipkinMessageHandler.
 - `ZipkinBaseUri` - is the zipkin scribe/collector server URI with port to send the Spans
 - `Domain` - is a valid public facing base url for your app instance. Zipkin will use to label the trace.
 - `SpanProcessorBatchSize` - how many Spans should be sent to the zipkin scribe/collector in one go.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This will happen if :
 ## Configurations
 Please use `ZipkinConig` class to configure the module and verify these values and modify them according to your service/environment.
 
-- `Enable` - true: enable ZipkinMiddleware/ZipkinMessageHandler, false: disable ZipkinMiddleware/ZipkinMessageHandler.
+- `BypassMode` - false: enable ZipkinMiddleware/ZipkinMessageHandler, enable: disable ZipkinMiddleware/ZipkinMessageHandler.
 - `ZipkinBaseUri` - is the zipkin scribe/collector server URI with port to send the Spans
 - `Domain` - is a valid public facing base url for your app instance. Zipkin will use to label the trace.
 - `SpanProcessorBatchSize` - how many Spans should be sent to the zipkin scribe/collector in one go.
@@ -30,7 +30,7 @@ Please use `ZipkinConig` class to configure the module and verify these values a
 ```
 var config = new ZipkinConfig
 {
-	Enable = true,
+	BypassMode = false,
 	Domain = new Uri("https://yourservice.com"),
 	ZipkinBaseUri = new Uri("http://zipkin.xyz.net:9411"),
 	SpanProcessorBatchSize = 10,
@@ -56,7 +56,7 @@ public class Startup
     {
 		app.UseZipkin(new ZipkinConfig
 		{
-		    Enable = true,
+		    BypassMode = false,
 		    Domain = new Uri("https://yourservice.com"),
 			ZipkinBaseUri = new Uri("http://zipkin.xyz.net:9411"),
 			SpanProcessorBatchSize = 10,

--- a/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
@@ -6,7 +6,7 @@ namespace Medidata.ZipkinTracer.Core
 {
     public interface IZipkinConfig
     {
-        bool Enable { get; set; }
+        bool BypassMode { get; set; }
         Uri ZipkinBaseUri { get; set; }
         Uri Domain { get; set; }
         uint SpanProcessorBatchSize { get; set; }

--- a/src/Medidata.ZipkinTracer.Core/Middlewares/ZipkinMiddleware.cs
+++ b/src/Medidata.ZipkinTracer.Core/Middlewares/ZipkinMiddleware.cs
@@ -28,7 +28,7 @@ namespace Medidata.ZipkinTracer.Core.Middlewares
     {
         public static void UseZipkin(this IAppBuilder app, IZipkinConfig config)
         {
-            if (config.Enable)
+            if (!config.BypassMode)
             {
                 config.Validate();
                 app.Use<ZipkinMiddleware>(config);

--- a/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
@@ -28,7 +28,7 @@ namespace Medidata.ZipkinTracer.Core
             if (spanCollectorBuilder == null) throw new ArgumentNullException(nameof(spanCollectorBuilder));
 
             var traceProvider = new TraceProvider(zipkinConfig, context);
-            IsTraceOn = zipkinConfig.Enable && IsTraceProviderSamplingOn(traceProvider);
+            IsTraceOn = !zipkinConfig.BypassMode && IsTraceProviderSamplingOn(traceProvider);
 
             if (!IsTraceOn)
                 return;

--- a/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
@@ -7,7 +7,7 @@ namespace Medidata.ZipkinTracer.Core
 {
     public class ZipkinConfig : IZipkinConfig
     {
-        public bool Enable { get; set; } = true;
+        public bool BypassMode { get; set; } = false;
         public Uri ZipkinBaseUri { get; set; }
         public Uri Domain { get; set; }
         public uint SpanProcessorBatchSize { get; set; }


### PR DESCRIPTION
@lschreck-mdsol @bvillanueva-mdsol @mdsol/monitoring-sentinels change property name from `Enable` to `BypassMode` for consistency between MAuth and Zipkin middleware. Please review and merge.