### PR TITLE
[MCC-217677] use delegate for BypassMode 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This will happen if :
 ## Configurations
 Please use `ZipkinConig` class to configure the module and verify these values and modify them according to your service/environment.
 
-- `BypassMode` - **false**: enable ZipkinMiddleware/ZipkinMessageHandler, **true**: disable ZipkinMiddleware/ZipkinMessageHandler.
+- `Bypass` - **false**: enable ZipkinMiddleware/ZipkinMessageHandler, **true**: disable ZipkinMiddleware/ZipkinMessageHandler.
 - `ZipkinBaseUri` - is the zipkin scribe/collector server URI with port to send the Spans
 - `Domain` - is a valid public facing base url for your app instance. Zipkin will use to label the trace.
 - `SpanProcessorBatchSize` - how many Spans should be sent to the zipkin scribe/collector in one go.
@@ -30,7 +30,7 @@ Please use `ZipkinConig` class to configure the module and verify these values a
 ```
 var config = new ZipkinConfig
 {
-	BypassMode = false,
+	Bypass = request => request.Uri.AbsolutePath.StartsWith("/allowed"),
 	Domain = new Uri("https://yourservice.com"),
 	ZipkinBaseUri = new Uri("http://zipkin.xyz.net:9411"),
 	SpanProcessorBatchSize = 10,
@@ -56,7 +56,6 @@ public class Startup
     {
 		app.UseZipkin(new ZipkinConfig
 		{
-		    BypassMode = false,
 		    Domain = new Uri("https://yourservice.com"),
 			ZipkinBaseUri = new Uri("http://zipkin.xyz.net:9411"),
 			SpanProcessorBatchSize = 10,

--- a/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
@@ -6,7 +6,7 @@ namespace Medidata.ZipkinTracer.Core
 {
     public interface IZipkinConfig
     {
-        bool BypassMode { get; set; }
+        Predicate<IOwinRequest> Bypass { get; set; }
         Uri ZipkinBaseUri { get; set; }
         Uri Domain { get; set; }
         uint SpanProcessorBatchSize { get; set; }

--- a/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
@@ -16,19 +16,20 @@ namespace Medidata.ZipkinTracer.Core
         public ITraceProvider TraceProvider { get; }
         public IZipkinConfig ZipkinConfig { get; }
 
-        public ZipkinClient(ILog logger, IZipkinConfig zipkinConfig, IOwinContext context = null)
+        public ZipkinClient(ILog logger, IZipkinConfig zipkinConfig, IOwinContext context)
             : this (logger, zipkinConfig, new SpanCollectorBuilder(), context)
         {
         }
 
-        public ZipkinClient(ILog logger, IZipkinConfig zipkinConfig, ISpanCollectorBuilder spanCollectorBuilder, IOwinContext context = null)
+        public ZipkinClient(ILog logger, IZipkinConfig zipkinConfig, ISpanCollectorBuilder spanCollectorBuilder, IOwinContext context)
         {
             if (logger == null) throw new ArgumentNullException(nameof(logger));
             if (zipkinConfig == null) throw new ArgumentNullException(nameof(zipkinConfig));
             if (spanCollectorBuilder == null) throw new ArgumentNullException(nameof(spanCollectorBuilder));
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             var traceProvider = new TraceProvider(zipkinConfig, context);
-            IsTraceOn = !zipkinConfig.BypassMode && IsTraceProviderSamplingOn(traceProvider);
+            IsTraceOn = !zipkinConfig.Bypass(context.Request) && IsTraceProviderSamplingOn(traceProvider);
 
             if (!IsTraceOn)
                 return;

--- a/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
@@ -7,7 +7,7 @@ namespace Medidata.ZipkinTracer.Core
 {
     public class ZipkinConfig : IZipkinConfig
     {
-        public bool BypassMode { get; set; } = false;
+        public Predicate<IOwinRequest> Bypass { get; set; } = r => false;
         public Uri ZipkinBaseUri { get; set; }
         public Uri Domain { get; set; }
         public uint SpanProcessorBatchSize { get; set; }


### PR DESCRIPTION
@lschreck-mdsol @bvillanueva-mdsol @mdsol/monitoring-sentinels use delegate for bypass mode to keep consistency with other middleware. Please review.