### PR TITLE
Make it easier to configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ service/environment.
 var config = new ZipkinConfig
 {
 	Bypass = request => request.Uri.AbsolutePath.StartsWith("/allowed"),
-	Domain = new Uri("https://yourservice.com"),
+	Domain = request => new Uri("https://yourservice.com"), // or, you might like to derive a value from the request, like r => new Uri($"{r.Scheme}://{r.Host}"),
 	ZipkinBaseUri = new Uri("http://zipkin.xyz.net:9411"),
 	SpanProcessorBatchSize = 10,
 	SampleRate = 0.5,

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ service/environment.
   - **true**: Disables the ZipkinMiddleware/ZipkinMessageHandler
 - `ZipkinBaseUri` - is the zipkin scribe/collector server URI with port to send the Spans
 - `Domain` - is a valid public facing base url for your app instance. Zipkin will use to label the trace.
+  - by default this looks at the incoming requests and uses the hostname from them. It's a `Func<IOwinRequest, Uri>` - customise this to your requirements.
 - `SpanProcessorBatchSize` - how many Spans should be sent to the zipkin scribe/collector in one go.
 - `SampleRate` - 1 decimal point float value between 0 and 1. This value will determine randomly if the current request will be traced or not.	 
 - `NotToBeDisplayedDomainList`(optional) - It will be used when logging host name by excluding these strings in service name attribute

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ service/environment.
 var config = new ZipkinConfig
 {
 	Bypass = request => request.Uri.AbsolutePath.StartsWith("/allowed"),
-	Domain = request => new Uri("https://yourservice.com"), // or, you might like to derive a value from the request, like r => new Uri($"{r.Scheme}://{r.Host}"),
+	Domain = request => new Uri("https://yourservice.com"), // or, you might like to derive a value from the request, like r => new Uri($"{r.Scheme}{Uri.SchemeDelimiter}{r.Host}"),
 	ZipkinBaseUri = new Uri("http://zipkin.xyz.net:9411"),
 	SpanProcessorBatchSize = 10,
 	SampleRate = 0.5,

--- a/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
@@ -10,7 +10,7 @@ namespace Medidata.ZipkinTracer.Core
 
         Uri ZipkinBaseUri { get; set; }
 
-        Uri Domain { get; set; }
+        Func<IOwinRequest, Uri> Domain { get; set; }
 
         uint SpanProcessorBatchSize { get; set; }
 

--- a/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
@@ -43,7 +43,7 @@ namespace Medidata.ZipkinTracer.Core
                     spanCollector,
                     new ServiceEndpoint(),
                     zipkinConfig.NotToBeDisplayedDomainList,
-                    zipkinConfig.Domain);
+                    zipkinConfig.Domain(context.Request));
 
                 TraceProvider = traceProvider;
             }

--- a/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
@@ -9,7 +9,7 @@ namespace Medidata.ZipkinTracer.Core
     {
         public Predicate<IOwinRequest> Bypass { get; set; } = r => false;
         public Uri ZipkinBaseUri { get; set; }
-        public Uri Domain { get; set; }
+        public Func<IOwinRequest, Uri> Domain { get; set; }
         public uint SpanProcessorBatchSize { get; set; }
         public IList<string> ExcludedPathList { get; set; } = new List<string>();
         public double SampleRate { get; set; }
@@ -24,7 +24,7 @@ namespace Medidata.ZipkinTracer.Core
 
             if (Domain == null)
             {
-                throw new ArgumentNullException("Domain");
+                Domain = request => new Uri(request.Uri.Host);
             }
 
             if (ExcludedPathList == null)

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinClientTests.cs
@@ -536,7 +536,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             return new ZipkinConfig
             {
                 ZipkinBaseUri = new Uri("http://zipkin.com"),
-                Domain = new Uri("http://server.com"),
+                Domain = r => new Uri("http://server.com"),
                 SpanProcessorBatchSize = 123,
                 ExcludedPathList = new List<string> { "/foo", "/bar", "/baz" },
                 SampleRate = 0.5,

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinConfigTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinConfigTests.cs
@@ -17,7 +17,7 @@ namespace Medidata.ZipkinTracer.Core.Test
             _sut = new ZipkinConfig
             {
                 ZipkinBaseUri = new Uri("http://zipkin.com"),
-                Domain = new Uri("http://server.com"),
+                Domain = r => new Uri("http://server.com"),
                 SpanProcessorBatchSize = fixture.Create<uint>(),
                 ExcludedPathList = new List<string>(),
                 SampleRate = 0,
@@ -28,14 +28,6 @@ namespace Medidata.ZipkinTracer.Core.Test
         [TestMethod]
         public void Validate()
         {
-            _sut.Validate();
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void ValidateWithNullZipkinBaseUri()
-        {
-            _sut.Domain = null;
             _sut.Validate();
         }
 
@@ -68,14 +60,6 @@ namespace Medidata.ZipkinTracer.Core.Test
         public void ValidateWithInvalidSampleRate()
         {
             _sut.SampleRate = 1.1;
-            _sut.Validate();
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void ValidateWithNullDomain()
-        {
-            _sut.Domain = null;
             _sut.Validate();
         }
 


### PR DESCRIPTION
Change the `Domain` part of configuration so that it's contextual and sensibly-defaulted

Rather than supply the domain at configuration-time, make it possible to set this dynamically according to the traffic that is reaching the endpoints - default it to use the hostname that the traffic is aimed at

To retain the previous behaviour, use `(r) => new Uri("some value")` and completely ignore the request context