### PR TITLE
Illustrate how more context can be published

### DIFF
--- a/src/Medidata.ZipkinTracer.Core/ITracerClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ITracerClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using Medidata.ZipkinTracer.Models;
+using Microsoft.Owin;
 
 namespace Medidata.ZipkinTracer.Core
 {
@@ -10,11 +11,11 @@ namespace Medidata.ZipkinTracer.Core
 
         ITraceProvider TraceProvider { get; }
 
-        Span StartServerTrace(Uri requestUri, string methodName);
+        Span StartServerTrace(IOwinRequest request);
 
         Span StartClientTrace(Uri remoteUri, string methodName, ITraceProvider trace);
 
-        void EndServerTrace(Span serverSpan);
+        void EndServerTrace(Span serverSpan, IOwinContext context);
 
         void EndClientTrace(Span clientSpan, int statusCode);
 

--- a/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/IZipkinConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Medidata.ZipkinTracer.Models;
 using Microsoft.Owin;
 
 namespace Medidata.ZipkinTracer.Core
@@ -23,5 +24,7 @@ namespace Medidata.ZipkinTracer.Core
         bool ShouldBeSampled(IOwinContext context, string sampled);
 
         void Validate();
+        IEnumerable<BinaryAnnotation> ExtraBinaryAnnotationsToAddBasedOnRequest(IOwinContext context);
+        IEnumerable<BinaryAnnotation> ExtraBinaryAnnotationsToAddBasedOnResponse(IOwinContext context);
     }
 }

--- a/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinClient.cs
@@ -90,7 +90,7 @@ namespace Medidata.ZipkinTracer.Core
             }
         }
 
-        public Span StartServerTrace(Uri requestUri, string methodName)
+        public Span StartServerTrace(IOwinRequest request)
         {
             if (!IsTraceOn)
                 return null;
@@ -98,11 +98,12 @@ namespace Medidata.ZipkinTracer.Core
             try
             {
                 return spanTracer.ReceiveServerSpan(
-                    methodName.ToLower(),
+                    request.Method.ToLower(),
                     TraceProvider.TraceId,
                     TraceProvider.ParentSpanId,
                     TraceProvider.SpanId,
-                    requestUri);
+                    request.Uri,
+                    ZipkinConfig.ExtraBinaryAnnotationsToAddBasedOnRequest(request.Context));
             }
             catch (Exception ex)
             {
@@ -111,14 +112,14 @@ namespace Medidata.ZipkinTracer.Core
             }
         }
 
-        public void EndServerTrace(Span serverSpan)
+        public void EndServerTrace(Span serverSpan, IOwinContext context)
         {
             if (!IsTraceOn)
                 return;
 
             try
             {
-                spanTracer.SendServerSpan(serverSpan);
+                spanTracer.SendServerSpan(serverSpan, ZipkinConfig.ExtraBinaryAnnotationsToAddBasedOnResponse(context));
             }
             catch (Exception ex)
             {

--- a/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
+++ b/src/Medidata.ZipkinTracer.Core/ZipkinConfig.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Medidata.ZipkinTracer.Models;
 using Microsoft.Owin;
 
 namespace Medidata.ZipkinTracer.Core
@@ -47,6 +48,21 @@ namespace Medidata.ZipkinTracer.Core
                 throw new ArgumentNullException("NotToBeDisplayedDomainList");
             }
         }
+
+        public virtual IEnumerable<BinaryAnnotation> ExtraBinaryAnnotationsToAddBasedOnRequest(IOwinContext context)
+        {
+            return new List<BinaryAnnotation>();
+        }
+
+        public virtual IEnumerable<BinaryAnnotation> ExtraBinaryAnnotationsToAddBasedOnResponse(IOwinContext context)
+        {
+            return new List<BinaryAnnotation>
+            {
+                new BinaryAnnotation { Key = "http.response.status", Value = context.Response.StatusCode },
+                new BinaryAnnotation { Key = "http.response.size", Value = context.Response.ContentLength }
+            };
+        }
+
 
         public bool ShouldBeSampled(IOwinContext context, string sampled)
         {


### PR DESCRIPTION
**I don't recommend you merge this** - I have paid zero attention to maintaining the tests (they don't compile) because I'm doing this slapdash within a hackathon. _I_ would not merge this if someone came along with it.

However, _as far as illustrating what I've done_, it's sufficient, I reckon. This is my last day at JE, so I won't promise to come back and finish this - I'm pushing it because you were interested.

I think with a bit more thought, it's possible to do this in a no-breaking-changes way (most of the things in this library are public, not internal, so that's a concern). I think I'd be tempted to add the `IOwinContext` onto the span as a property, so there's only the `ReceiveServerSpan` and `SendClientSpan` methods that need to be changed.

The main point, though, is to allow library consumers to decide which binary annotations to publish by themselves. At JE, we have several correlation headers and environment variables and things like that, so our own ZipkinConfig looks vaguely like

```csharp
    public class JustEatZipkinConfig : ZipkinConfig
    {
        private readonly IAppSettings _settings;

        public JustEatZipkinConfig(NameValueCollection settings)
        {
            _settings = new AppSettingsExtended(settings);
        }

        public override IEnumerable<BinaryAnnotation> ExtraBinaryAnnotationsToAddBasedOnRequest(IOwinContext context)
        {
            foreach (var fromAppSetting in FromAppSettings())
            {
                yield return fromAppSetting;
            }

            foreach (var fromHeader in FromHeadersOnRequest(context))
            {
                yield return fromHeader;
            }

            foreach (var annotation in base.ExtraBinaryAnnotationsToAddBasedOnRequest(context))
            {
                yield return annotation;
            }

            // yield return something_that_gets_our_assemblyinformationalversion_value
        }

        protected virtual IEnumerable<BinaryAnnotation> FromHeadersOnRequest(IOwinContext context)
        {
            yield return FromHeader(context, "our-request-id");
            yield return FromHeader(context, "our-conversation-id");
        }

        protected virtual IEnumerable<BinaryAnnotation> FromAppSettings()
        {
            yield return FromAppSetting("our_environment");
            yield return FromAppSetting("our_name");
            yield return FromAppSetting("our_server_id");
        }

        protected BinaryAnnotation FromAppSetting(string key)
        {
            return new BinaryAnnotation
            {
                Key = KeyForEnvironmentBinaryAnnotation(key),
                Value = _settings.AppSetting(key, () => string.Format(CultureInfo.InvariantCulture, "unknown-appsetting:{0}", key))
            };
        }

        protected string KeyForEnvironmentBinaryAnnotation(string name)
        {
            return string.Format(CultureInfo.InvariantCulture, "app.environment.{0}", name);
        }

        protected BinaryAnnotation FromHeader(IOwinContext context, string headerName)
        {
            return new BinaryAnnotation
            {
                Key = KeyForHeaderBinaryNotation(headerName),
                Value = HeaderOrDefault(context, headerName)
            };
        }

        protected string KeyForHeaderBinaryNotation(string headerName)
        {
            return string.Format(CultureInfo.InvariantCulture, "http.headers.{0}", headerName);
        }

        private static string HeaderOrDefault(IOwinContext context, string headerName)
        {
            if (context == null || context.Request == null || context.Request.Headers == null ||
                !context.Request.Headers.ContainsKey(headerName))
            {
                return "";
            }
            return context.Request.Headers[headerName];
        }
    }

```