### PR TITLE
removed ServiceEndpoint magic number for port

### DIFF
--- a/src/Medidata.ZipkinTracer.Core/ServiceEndpoint.cs
+++ b/src/Medidata.ZipkinTracer.Core/ServiceEndpoint.cs
@@ -8,12 +8,8 @@ namespace Medidata.ZipkinTracer.Core
 {
     public class ServiceEndpoint 
     {
-        public virtual Endpoint GetLocalEndpoint(string serviceName, ushort port = 443)
+        public virtual Endpoint GetLocalEndpoint(string serviceName, ushort port)
         {
-            // personally, it should have been nullable short for port. but since zipkin server requires it, 443
-            // has be chosen to be that magic number as most servers have it.
-            // TODO: get rid of this magic number
-
             return new Endpoint()
             {
                 ServiceName = serviceName,

--- a/src/Medidata.ZipkinTracer.Core/SpanTracer.cs
+++ b/src/Medidata.ZipkinTracer.Core/SpanTracer.cs
@@ -9,6 +9,7 @@ namespace Medidata.ZipkinTracer.Core
     {
         private SpanCollector spanCollector;
         private string serviceName;
+        private ushort servicePort;
         private ServiceEndpoint zipkinEndpoint;
         private IEnumerable<string> zipkinNotToBeDisplayedDomainList;
 
@@ -24,6 +25,7 @@ namespace Medidata.ZipkinTracer.Core
             this.zipkinNotToBeDisplayedDomainList = zipkinNotToBeDisplayedDomainList;
             var domainHost = domain.Host;
             this.serviceName = CleanServiceName(domainHost);
+            this.servicePort = (ushort)domain.Port;
         }
 
         public virtual Span ReceiveServerSpan(string spanName, string traceId, string parentSpanId, string spanId, Uri requestUri)
@@ -70,7 +72,7 @@ namespace Medidata.ZipkinTracer.Core
         public virtual Span SendClientSpan(string spanName, string traceId, string parentSpanId, string spanId, Uri remoteUri)
         {
             var newSpan = CreateNewSpan(spanName, traceId, parentSpanId, spanId);
-            var serviceEndpoint = zipkinEndpoint.GetLocalEndpoint(serviceName);
+            var serviceEndpoint = zipkinEndpoint.GetLocalEndpoint(serviceName, (ushort)remoteUri.Port);
             var clientServiceName = CleanServiceName(remoteUri.Host);
 
             var annotation = new Annotation
@@ -130,7 +132,7 @@ namespace Medidata.ZipkinTracer.Core
 
             span.Annotations.Add(new Annotation()
             {
-                Host = zipkinEndpoint.GetLocalEndpoint(serviceName),
+                Host = zipkinEndpoint.GetLocalEndpoint(serviceName, servicePort),
                 Value = value
             });
         }
@@ -142,7 +144,7 @@ namespace Medidata.ZipkinTracer.Core
 
             span.Annotations.Add(new BinaryAnnotation()
             {
-                Host = zipkinEndpoint.GetLocalEndpoint(serviceName),
+                Host = zipkinEndpoint.GetLocalEndpoint(serviceName, servicePort),
                 Key = key,
                 Value = value
             });

--- a/tests/Medidata.ZipkinTracer.Core.Test/ZipkinEndpointTests.cs
+++ b/tests/Medidata.ZipkinTracer.Core.Test/ZipkinEndpointTests.cs
@@ -19,9 +19,10 @@ namespace Medidata.ZipkinTracer.Core.Test
         public void GetLocalEndpoint()
         {
             var serviceName = fixture.Create<string>();
+            var port = fixture.Create<ushort>();
 
             var zipkinEndpoint = new ServiceEndpoint();
-            var endpoint = zipkinEndpoint.GetLocalEndpoint(serviceName);
+            var endpoint = zipkinEndpoint.GetLocalEndpoint(serviceName, port);
 
             Assert.IsNotNull(endpoint);
             Assert.AreEqual(serviceName, endpoint.ServiceName);


### PR DESCRIPTION
require port to be passed in to all GetLocalEndpoint calls, and derive
from domain.Port in SpanTracer (similar to how serviceName is derived
from domain.Host)
