### PR TITLE
Don't force an inner handler if one is not provided

### DIFF
--- a/src/Medidata.ZipkinTracer.Core/Handlers/ZipkinMessageHandler.cs
+++ b/src/Medidata.ZipkinTracer.Core/Handlers/ZipkinMessageHandler.cs
@@ -9,8 +9,8 @@ namespace Medidata.ZipkinTracer.Core.Handlers
         private readonly ITracerClient _client;
 
         public ZipkinMessageHandler(ITracerClient client)
-            : this(client, new HttpClientHandler())
         {
+            _client = client;
         }
 
         public ZipkinMessageHandler(ITracerClient client, HttpMessageHandler innerHandler)


### PR DESCRIPTION
The current ctor is creating a new HttpClientHandler() for you if you don't provide one.  When you try to use multiple handlers like this:
```
var zipkinClient = new ZipkinClient(zipkinConfig, owinContext, zipkinSpanCollector);
var handlers = new DelegatingHandler[]
            {
                new ServiceDiscoveryHandler(serviceLocator),
                new HopHandler(owinContext.Request.Headers),
                new FailHandler(owinContext.GetServicesToFail()),
                new BearerTokenHandler(owinContext.Request), 
                new ZipkinMessageHandler(zipkinClient)
            };
return HttpClientFactory.Create(handlers);
```
you get this exception: 

> System.ArgumentException: The 'DelegatingHandler' list is invalid because the property 'InnerHandler' of 'ZipkinMessageHandler' is not null.

There's no need to create a new HttpClientHandler(), the base class will do it for you if you don't provide one.